### PR TITLE
Set default value for min_periods in trade command

### DIFF
--- a/commands/trade.js
+++ b/commands/trade.js
@@ -87,6 +87,7 @@ module.exports = function (program, conf) {
         console.log(('--buy_max_amt is deprecated, use --deposit instead!\n').red)
         so.deposit = so.buy_max_amt
       }
+      if (!so.min_periods) so.min_periods = 1
 
       so.selector = objectifySelector(selector || conf.selector)      
       var engine = engineFactory(s, conf)


### PR DESCRIPTION
Using paper mode, the `min_periods` option was used without being defined. It would lead to date calculation returning `NaN`, and thus provoking errors (at least on Binance exchange).

This commit fixes this.