### PR TITLE
* corrected currency for BCHBTC market of bitstamp exchange

### DIFF
--- a/extensions/exchanges/bitstamp/products.json
+++ b/extensions/exchanges/bitstamp/products.json
@@ -128,7 +128,7 @@
   {
     "id": "BCHBTC",
     "asset": "BCH",
-    "currency": "EUR",
+    "currency": "BTC",
     "min_size": "0.001",
     "max_size": "1000000",
     "increment": "0.00001",


### PR DESCRIPTION
incorrect currency was specified here