### PR TITLE
notifier filter for completed trades

### DIFF
--- a/commands/trade.js
+++ b/commands/trade.js
@@ -57,6 +57,7 @@ module.exports = function (program, conf) {
     .option('--use_fee_asset', 'Using separated asset to pay for fees. Such as binance\'s BNB or Huobi\'s HT', Boolean, false)
     .option('--run_for <minutes>', 'Execute for a period of minutes then exit with status 0', String, null)
     .option('--debug', 'output detailed debug info')
+    .option('--only_completed_trades', 'Message filter for only completed trades to notifier.', Boolean, conf.notifiers.only_completed_trades)
     .action(function (selector, cmd) {
       var raw_opts = minimist(process.argv)
       var s = {options: JSON.parse(JSON.stringify(raw_opts))}
@@ -76,6 +77,7 @@ module.exports = function (program, conf) {
           so[k] = cmd[k]
         }
       })
+      so.only_completed_trades = (cmd.only_completed_trades || conf.only_completed_trades)
       so.currency_increment = cmd.currency_increment
       so.keep_lookback_periods = cmd.keep_lookback_periods
       so.use_prev_trades = (cmd.use_prev_trades||conf.use_prev_trades)

--- a/commands/trade.js
+++ b/commands/trade.js
@@ -57,7 +57,6 @@ module.exports = function (program, conf) {
     .option('--use_fee_asset', 'Using separated asset to pay for fees. Such as binance\'s BNB or Huobi\'s HT', Boolean, false)
     .option('--run_for <minutes>', 'Execute for a period of minutes then exit with status 0', String, null)
     .option('--debug', 'output detailed debug info')
-    .option('--only_completed_trades', 'Message filter for only completed trades to notifier.', Boolean, conf.notifiers.only_completed_trades)
     .action(function (selector, cmd) {
       var raw_opts = minimist(process.argv)
       var s = {options: JSON.parse(JSON.stringify(raw_opts))}
@@ -77,7 +76,7 @@ module.exports = function (program, conf) {
           so[k] = cmd[k]
         }
       })
-      so.only_completed_trades = (cmd.only_completed_trades || conf.only_completed_trades)
+      so.only_completed_trades = conf.only_completed_trades
       so.currency_increment = cmd.currency_increment
       so.keep_lookback_periods = cmd.keep_lookback_periods
       so.use_prev_trades = (cmd.use_prev_trades||conf.use_prev_trades)

--- a/commands/trade.js
+++ b/commands/trade.js
@@ -76,7 +76,6 @@ module.exports = function (program, conf) {
           so[k] = cmd[k]
         }
       })
-      so.only_completed_trades = conf.only_completed_trades
       so.currency_increment = cmd.currency_increment
       so.keep_lookback_periods = cmd.keep_lookback_periods
       so.use_prev_trades = (cmd.use_prev_trades||conf.use_prev_trades)

--- a/conf-sample.js
+++ b/conf-sample.js
@@ -177,6 +177,10 @@ c.min_prev_trades = 0
 // Notifiers:
 c.notifiers = {}
 
+//common
+
+c.notifiers.only_completed_trades = false // Filter to notifier's messages for getting Commpleted Trades info.
+
 // xmpp config
 c.notifiers.xmpp = {}
 c.notifiers.xmpp.on = false  // false xmpp disabled; true xmpp enabled (credentials should be correct)

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -425,12 +425,10 @@ module.exports = function (s, conf) {
               }, conf.wait_for_settlement)
             }
             else {
-              if(!conf.notifiers.only_completed_trades){
+              if(conf.notifiers && !conf.notifiers.only_completed_trades){
                 pushMessage('Buying ' + formatAsset(size, s.asset) + ' on ' + s.exchange.name.toUpperCase(), 'placing buy order at ' + formatCurrency(price, s.currency) + ', ' + formatCurrency(quote.bid - Number(price), s.currency) + ' under best bid\n')
-                doOrder()
-              } else {
-                doOrder()
               }
+              doOrder()
             }
           }
         }
@@ -477,12 +475,10 @@ module.exports = function (s, conf) {
               }, conf.wait_for_settlement)
             }
             else {
-              if(!conf.notifiers.only_completed_trades){
+              if(conf.notifiers && !conf.notifiers.only_completed_trades){
                 pushMessage('Selling ' + formatAsset(size, s.asset) + ' on ' + s.exchange.name.toUpperCase(), 'placing sell order at ' + formatCurrency(price, s.currency) + ', ' + formatCurrency(Number(price) - quote.bid, s.currency) + ' over best ask\n')
-                doOrder()
-              } else {
-                doOrder()
               }
+              doOrder()
             }
           }
         }

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -425,7 +425,7 @@ module.exports = function (s, conf) {
               }, conf.wait_for_settlement)
             }
             else {
-              if(!so.only_completed_trades){
+              if(!conf.notifiers.only_completed_trades){
                 pushMessage('Buying ' + formatAsset(size, s.asset) + ' on ' + s.exchange.name.toUpperCase(), 'placing buy order at ' + formatCurrency(price, s.currency) + ', ' + formatCurrency(quote.bid - Number(price), s.currency) + ' under best bid\n')
                 doOrder()
               } else {
@@ -477,7 +477,7 @@ module.exports = function (s, conf) {
               }, conf.wait_for_settlement)
             }
             else {
-              if(!so.only_completed_trades){
+              if(!conf.notifiers.only_completed_trades){
                 pushMessage('Selling ' + formatAsset(size, s.asset) + ' on ' + s.exchange.name.toUpperCase(), 'placing sell order at ' + formatCurrency(price, s.currency) + ', ' + formatCurrency(Number(price) - quote.bid, s.currency) + ' over best ask\n')
                 doOrder()
               } else {

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -425,8 +425,12 @@ module.exports = function (s, conf) {
               }, conf.wait_for_settlement)
             }
             else {
-              pushMessage('Buying ' + formatAsset(size, s.asset) + ' on ' + s.exchange.name.toUpperCase(), 'placing buy order at ' + formatCurrency(price, s.currency) + ', ' + formatCurrency(quote.bid - Number(price), s.currency) + ' under best bid\n')
-              doOrder()
+              if(!so.only_completed_trades){
+                pushMessage('Buying ' + formatAsset(size, s.asset) + ' on ' + s.exchange.name.toUpperCase(), 'placing buy order at ' + formatCurrency(price, s.currency) + ', ' + formatCurrency(quote.bid - Number(price), s.currency) + ' under best bid\n')
+                doOrder()
+              } else {
+                doOrder()
+              }
             }
           }
         }
@@ -473,8 +477,12 @@ module.exports = function (s, conf) {
               }, conf.wait_for_settlement)
             }
             else {
-              pushMessage('Selling ' + formatAsset(size, s.asset) + ' on ' + s.exchange.name.toUpperCase(), 'placing sell order at ' + formatCurrency(price, s.currency) + ', ' + formatCurrency(Number(price) - quote.bid, s.currency) + ' over best ask\n')
-              doOrder()
+              if(!so.only_completed_trades){
+                pushMessage('Selling ' + formatAsset(size, s.asset) + ' on ' + s.exchange.name.toUpperCase(), 'placing sell order at ' + formatCurrency(price, s.currency) + ', ' + formatCurrency(Number(price) - quote.bid, s.currency) + ' over best ask\n')
+                doOrder()
+              } else {
+                doOrder()
+              }
             }
           }
         }


### PR DESCRIPTION
when ı use notifer for seing my trades data, canceled orders become so big waste, then ı create a filter to zenbot for sending notifier only completed messages.