### PR TITLE
improve bollinger strategies

### DIFF
--- a/extensions/strategies/bollinger/strategy.js
+++ b/extensions/strategies/bollinger/strategy.js
@@ -23,9 +23,9 @@ module.exports = {
 
   onPeriod: function (s, cb) {
     if (s.period.bollinger) {
-      if (s.period.bollinger.upper && s.period.bollinger.lower) {
-        let upperBound = s.period.bollinger.upper[s.period.bollinger.upper.length-1]
-        let lowerBound = s.period.bollinger.lower[s.period.bollinger.lower.length-1]
+      if (s.period.bollinger.upperBound && s.period.bollinger.lowerBound) {
+        let upperBound = s.period.bollinger.upperBound
+        let lowerBound = s.period.bollinger.lowerBound
         if (s.period.close > (upperBound / 100) * (100 - s.options.bollinger_upper_bound_pct)) {
           s.signal = 'sell'
         } else if (s.period.close < (lowerBound / 100) * (100 + s.options.bollinger_lower_bound_pct)) {
@@ -41,9 +41,9 @@ module.exports = {
   onReport: function (s) {
     var cols = []
     if (s.period.bollinger) {
-      if (s.period.bollinger.upper && s.period.bollinger.lower) {
-        let upperBound = s.period.bollinger.upper[s.period.bollinger.upper.length-1]
-        let lowerBound = s.period.bollinger.lower[s.period.bollinger.lower.length-1]
+      if (s.period.bollinger.upperBound && s.period.bollinger.lowerBound) {
+        let upperBound = s.period.bollinger.upperBound
+        let lowerBound = s.period.bollinger.lowerBound
         var color = 'grey'
         if (s.period.close > (upperBound / 100) * (100 - s.options.bollinger_upper_bound_pct)) {
           color = 'green'

--- a/extensions/strategies/trend_bollinger/strategy.js
+++ b/extensions/strategies/trend_bollinger/strategy.js
@@ -34,10 +34,10 @@ module.exports = {
     }
 
     if (s.period.bollinger) {
-      if (s.period.bollinger.upper && s.period.bollinger.lower) {
+      if (s.period.bollinger.upperBound && s.period.bollinger.lowerBound) {
         s.signal = null // hold
-        let upperBound = s.period.bollinger.upper[s.period.bollinger.upper.length-1]
-        let lowerBound = s.period.bollinger.lower[s.period.bollinger.lower.length-1]
+        let upperBound = s.period.bollinger.upperBound
+        let lowerBound = s.period.bollinger.lowerBound
         if (s.period.close > (upperBound / 100) * (100 - s.options.bollinger_upper_bound_pct)) {
           s.last_hit_bollinger = 'upper'
         } else if (s.period.close < (lowerBound / 100) * (100 + s.options.bollinger_lower_bound_pct)) {
@@ -67,9 +67,9 @@ module.exports = {
   onReport: function (s) {
     var cols = []
     if (s.period.bollinger) {
-      if (s.period.bollinger.upper && s.period.bollinger.lower) {
-        let upperBound = s.period.bollinger.upper[s.period.bollinger.upper.length-1]
-        let lowerBound = s.period.bollinger.lower[s.period.bollinger.lower.length-1]
+      if (s.period.bollinger.upperBound && s.period.bollinger.lowerBound) {
+        let upperBound = s.period.bollinger.upperBound
+        let lowerBound = s.period.bollinger.lowerBound
         var color = 'grey'
         if (s.period.close > (upperBound / 100) * (100 - s.options.bollinger_upper_bound_pct)) {
           color = 'green'

--- a/lib/bollinger.js
+++ b/lib/bollinger.js
@@ -1,14 +1,26 @@
 // Bollinger Bands
 var bollingerbands = require('bollinger-bands')
+
 module.exports = function bollinger (s, key, length, source_key) {
   if (!source_key) source_key = 'close'
   if (s.lookback.length > length) {
+    // skip calculation if result already presented as we use historical data only,
+    // no need to recalculate for each individual trade
+    if (key in s.period) return
     let data = []
     for (var i=length-1; i>=0; i--) {
       data.push(s.lookback[i][source_key])
     }
-    let result = bollingerbands(data, length, s.options.bollinger_time)
-    s.period[key] = result
+    const result = bollingerbands(data, length, s.options.bollinger_time)
+    const upperBound = result.upper[result.upper.length-1]
+    const lowerBound = result.lower[result.lower.length-1]
+    const midBound = result.mid[result.mid.length-1]
+    const simple_result = {
+      upperBound : upperBound,
+      midBound: midBound,
+      lowerBound : lowerBound
+    }
+    s.period[key] = simple_result
   }
 }
 


### PR DESCRIPTION
* tiny performance improvement to skip calculation of bollinger bands for each trade.
see lib/bollinger.js
line with
if (key in s.period) return 
check

* keep only bands itself to decrease size of data on 2 weeks sample file size 
201 Kb vs 114 Kb

var data = [{"period_id":"h428313","size":"1h","time":1541926800000,"open":213.53,"high":213.58,"low":213.49,"close":213.49,"volume":466.78638,"close_time":1541930399999,"latest_trade_time":1541927220000,"bollinger":{"upper":[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,215.41419216485025],"mid":[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,213.73649999999998]

after the change:

var data = [{"period_id":"h428313","size":"1h","time":1541926800000,"open":213.53,"high":213.58,"low":213.49,"close":213.49,"volume":466.78638,"close_time":1541930399999,"latest_trade_time":1541927220000,"bollinger":{"upperBound":215.41419216485025,"midBound":213.73649999999998,"lowerBound":212.0588078351497}}