### PR TITLE
avg_slippage_pct should be used for taker orders

### DIFF
--- a/extensions/exchanges/sim/exchange.js
+++ b/extensions/exchanges/sim/exchange.js
@@ -202,7 +202,7 @@ module.exports = function sim (conf, s) {
     let price = buy_order.price
 
     // Add estimated slippage to price
-    if (so.order_type === 'maker') {
+    if (so.order_type === 'taker') {
       price = n(price).add(n(price).multiply(so.avg_slippage_pct / 100)).format('0.00000000')
     }
 
@@ -242,7 +242,7 @@ module.exports = function sim (conf, s) {
     let price = sell_order.price
 
     // Add estimated slippage to price
-    if (so.order_type === 'maker') {
+    if (so.order_type === 'taker') {
       price = n(price).subtract(n(price).multiply(so.avg_slippage_pct / 100)).format('0.00000000')
     }
 


### PR DESCRIPTION
It looks like original code had
https://github.com/DeviaVir/zenbot/issues/1109#issuecomment-357411767

but later this changed

https://github.com/DeviaVir/zenbot/pull/1378

@DeviaVir , @glennfu , @krystophv  can you guys review my fix. I feel this can be important.