### PR TITLE
trade.js: avoid fetching last trade twice on exchange.getTrades() call.

### DIFF
--- a/commands/trade.js
+++ b/commands/trade.js
@@ -625,7 +625,10 @@ module.exports = function (program, conf) {
             })
           })
         }
-        var opts = {product_id: so.selector.product_id, from: trade_cursor}
+        var opts = {
+          product_id: so.selector.product_id,
+          from: trade_cursor + 1
+        }
         s.exchange.getTrades(opts, function (err, trades) {
           if (err) {
             if (err.code === 'ETIMEDOUT' || err.code === 'ENOTFOUND' || err.code === 'ECONNRESET') {


### PR DESCRIPTION
exchange.getTrades()'s "from" argument is inclusive. This commit add a millisecond to it, in order to avoid fetching a second time the last trade of the previous batch.

@DeviaVir I *think* `getTrades()` is supposed to be inclusive, but I'm not sure of it. `commands/backfill.js` uses it as if it's inclusive, but `commands/trade.js` does not (without this pull request).
Anyway, one of the two commands is wrong, and it would make more sense to consider it inclusive.

It improves the results, at least for Binance (I've not tested the others exchanges): Binance was using several times the same values due to this bug.
Note that Binance has others bugs (it uses OHLCV instead of trades). I plan to fix that in future commits, when I figure out what's the proper way to fix this.
