### PR TITLE
bitfinex backfill is broken

### DIFF
--- a/commands/backfill.js
+++ b/commands/backfill.js
@@ -8,6 +8,7 @@ module.exports = function (program, conf) {
     .command('backfill [selector]')
     .description('download historical trades for analysis')
     .option('--conf <path>', 'path to optional conf overrides file')
+    .option('--debug', 'output detailed debug info')
     .option('-d, --days <days>', 'number of days to acquire (default: ' + conf.days + ')', Number, conf.days)
     .action(function (selector, cmd) {
       selector = objectifySelector(selector || conf.selector)


### PR DESCRIPTION
 This is first part to fix backfill functionality only

I have used rate limit recommendation

https://bitcoin.stackexchange.com/questions/36952/bitfinex-api-limit

with some modifications as I found that 1 request per second is too often for bitfinex so I use 2000 ms timeout to retrieve bitfinex trades.