### PR TITLE
added --filename to trade --help

### DIFF
--- a/commands/trade.js
+++ b/commands/trade.js
@@ -27,6 +27,7 @@ module.exports = function (program, conf) {
     .option('--paper', 'use paper trading mode (no real trades will take place)', Boolean, false)
     .option('--manual', 'watch price and account balance, but do not perform trades automatically', Boolean, false)
     .option('--non_interactive', 'disable keyboard inputs to the bot', Boolean, false)
+    .option('--filename <filename>', 'filename for the result output (ex: result.html). "none" to disable', String, conf.filename)
     .option('--currency_capital <amount>', 'for paper trading, amount of start capital in currency', Number, conf.currency_capital)
     .option('--asset_capital <amount>', 'for paper trading, amount of start capital in asset', Number, conf.asset_capital)
     .option('--avg_slippage_pct <pct>', 'avg. amount of slippage to apply to paper trades', Number, conf.avg_slippage_pct)


### PR DESCRIPTION
according to #1775 the possibility to define a filename is not listed in `trade --help`, but works... this probably avoids future questions.

---

hopefully this commit is correct, because i sadly have hardly any idea of js!?