### PR TITLE
Fix incorrectly calculated CCI indicator

### DIFF
--- a/lib/cci.js
+++ b/lib/cci.js
@@ -1,14 +1,16 @@
 module.exports = function cci (s, key, length, c) {
   s.period['TP'] = (s.period.high + s.period.low + s.period.close) / 3
-  if (s.lookback.length >= length) {
-    let avg_TP = s.lookback
-      .slice(0, length)
+  if (s.lookback.length >= length - 1) {
+    let period_list = s.lookback
+      .slice(0, length - 1)
+    period_list.unshift(s.period)
+
+    let avg_TP = period_list
       .reduce((sum, tp) => {
         return sum + tp.TP
       }, 0)
     s.period['avg_TP'] = avg_TP / length
-    let meanDev = s.lookback
-      .slice(0, length)
+    let meanDev = period_list
       .reduce((sum, cur) => {
         cur = Math.abs(cur.TP - s.period.avg_TP)
         return sum + cur


### PR DESCRIPTION
The CCI function was using `s.lookback` only to compute values, without the last period in `s.period`. This commit fixes this.
New CCI values has been compared to the CCI indicator in TradingView. Values are now indentical.