### PR TITLE
Fixed breaking change of bitfinex node api v2.0.0

### DIFF
--- a/extensions/exchanges/bitfinex/exchange.js
+++ b/extensions/exchanges/bitfinex/exchange.js
@@ -222,7 +222,7 @@ module.exports = function bitfinex (conf) {
       ws_connecting = true
       ws_connected = false
 
-      ws_client = new BFX({apiKey: conf.bitfinex.key, apiSecret: conf.bitfinex.secret}).ws()
+      ws_client = new BFX({apiKey: conf.bitfinex.key, apiSecret: conf.bitfinex.secret, transform: true}).ws()
 
       ws_client
         .on('open', wsOpen)

--- a/extensions/exchanges/bitfinex/exchange.js
+++ b/extensions/exchanges/bitfinex/exchange.js
@@ -222,7 +222,7 @@ module.exports = function bitfinex (conf) {
       ws_connecting = true
       ws_connected = false
 
-      ws_client = new BFX(conf.bitfinex.key, conf.bitfinex.secret, {version: 2, transform: true}).ws
+      ws_client = new BFX({apiKey: conf.bitfinex.key, apiSecret: conf.bitfinex.secret}).ws()
 
       ws_client
         .on('open', wsOpen)


### PR DESCRIPTION
Version 2.0.0 of the bitfinex node API introduced a new breaking change:
https://github.com/bitfinexcom/bitfinex-api-node#version-200-breaking-changes

This pull-request fixes the issue.

Zenbot throws the following Error, if this fix is not applied:

```
/root/zenbot/node_modules/mongodb/lib/utils.js:132
      throw err;
      ^

Error: constructor takes an object since version 2.0.0, see:
https://github.com/bitfinexcom/bitfinex-api-node#version-200-breaking-changes

    at new BFX (/root/zenbot/node_modules/bitfinex-api-node/index.js:32:13)
    at wsClient (/root/zenbot/extensions/exchanges/bitfinex/exchange.js:225:19)
    at Object.getBalance (/root/zenbot/extensions/exchanges/bitfinex/exchange.js:499:9)
    at Object.syncBalance (/root/zenbot/lib/engine.js:211:16)
    at /root/zenbot/commands/trade.js:445:22
    at result (/root/zenbot/node_modules/mongodb/lib/utils.js:414:17)
    at executeCallback (/root/zenbot/node_modules/mongodb/lib/utils.js:406:9)
    at handleCallback (/root/zenbot/node_modules/mongodb/lib/utils.js:128:55)
    at cursor.close (/root/zenbot/node_modules/mongodb/lib/operations/cursor_ops.js:211:62)
    at handleCallback (/root/zenbot/node_modules/mongodb/lib/utils.js:128:55)
    at completeClose (/root/zenbot/node_modules/mongodb/lib/cursor.js:893:14)
    at Cursor.close (/root/zenbot/node_modules/mongodb/lib/cursor.js:912:10)
    at cursor._next (/root/zenbot/node_modules/mongodb/lib/operations/cursor_ops.js:211:23)
    at handleCallback (/root/zenbot/node_modules/mongodb-core/lib/cursor.js:203:5)
    at _setCursorNotifiedImpl (/root/zenbot/node_modules/mongodb-core/lib/cursor.js:561:38)
    at self._endSession (/root/zenbot/node_modules/mongodb-core/lib/cursor.js:569:46)
    at Cursor._endSession (/root/zenbot/node_modules/mongodb-core/lib/cursor.js:194:5)
    at Cursor._endSession (/root/zenbot/node_modules/mongodb/lib/cursor.js:226:59)
    at _setCursorNotifiedImpl (/root/zenbot/node_modules/mongodb-core/lib/cursor.js:569:17)
    at setCursorNotified (/root/zenbot/node_modules/mongodb-core/lib/cursor.js:561:3)
    at /root/zenbot/node_modules/mongodb-core/lib/cursor.js:621:16
    at queryCallback (/root/zenbot/node_modules/mongodb-core/lib/cursor.js:289:5)
```
