### PR TITLE
Fix order time on simulation

### DIFF
--- a/extensions/exchanges/sim/exchange.js
+++ b/extensions/exchanges/sim/exchange.js
@@ -176,6 +176,8 @@ module.exports = function sim (conf, s) {
 
     processTrade: function(trade) {
       var orders_changed = false
+      
+      now = trade.time
 
       _.each(openOrders, function(order) {
         if (trade.time - order.time < so.order_adjust_time) {


### PR DESCRIPTION
`now` is [used](https://github.com/DeviaVir/zenbot/blob/unstable/extensions/exchanges/sim/exchange.js#L113) but never set, this was causing the order time to be undefined on simulations