### PR TITLE
Add missing period_length option to fix dema strategy

### DIFF
--- a/extensions/strategies/dema/strategy.js
+++ b/extensions/strategies/dema/strategy.js
@@ -10,6 +10,7 @@ module.exports = {
 
   getOptions: function () {
     this.option('period', 'period length', String, '1h')
+    this.option('period_length', 'period length, same as --period', String, '1h')
     this.option('min_periods', 'min. number of history periods', Number, 21)
     this.option('ema_short_period', 'number of periods for the shorter EMA', Number, 10)
     this.option('ema_long_period', 'number of periods for the longer EMA', Number, 21)


### PR DESCRIPTION
Just cloned Zenbot, and got a timebucket parse error when trying to run the dema strategy. Looks like the dema strategy hasn't been updated to use the `period_length` option in addition to the `period` option.