### PR TITLE
Fix min_periods should be set after the strategy set its defaults #1771

### DIFF
--- a/commands/trade.js
+++ b/commands/trade.js
@@ -98,11 +98,10 @@ module.exports = function (program, conf) {
         console.log(('--buy_max_amt is deprecated, use --deposit instead!\n').red)
         so.deposit = so.buy_max_amt
       }
-      if (!so.min_periods) so.min_periods = 1
-
       so.selector = objectifySelector(selector || conf.selector)      
       var engine = engineFactory(s, conf)
       var collectionServiceInstance = collectionService(conf)
+      if (!so.min_periods) so.min_periods = 1
 
       const keyMap = new Map()
       keyMap.set('b', 'limit'.grey + ' BUY'.green)


### PR DESCRIPTION
If min_periods is set to 1 before the strategy had set its defaults actually makes the strategy defaults to be ignored and lead to some bugs like #1771 
To make mater worse the bug is reviewed only in trading. 
I think setting it last would fix the problem and not cause any problems 