### PR TITLE
Avoid returning trades that have been ever returned in bitstamp getTrades()

### DIFF
--- a/extensions/exchanges/bitstamp/exchange.js
+++ b/extensions/exchanges/bitstamp/exchange.js
@@ -147,7 +147,6 @@ module.exports = function bitstamp (conf) {
       price: data.price,
       side: data.type === 0 ? 'buy' : 'sell'
     })
-    if (wstrades.length > 30) wstrades.splice(0,10)
   })
   //-----------------------------------------------------
 
@@ -199,10 +198,7 @@ module.exports = function bitstamp (conf) {
       var wait = 2   // Seconds
       var func_args = [].slice.call(arguments) 
       if (wstrades.length === 0) return retry('getTrades', wait, func_args)
-      var t = wstrades
-      var trades = t.map(function (trade) {
-        return (trade)
-      })
+      var trades = wstrades.splice(0, wstrades.length)
       cb(null, trades)
     },
 


### PR DESCRIPTION
Currently this function returns everything in wstrades array which
doesn't change as long as its length is not larger than 30. This means
if getTrades() gets called multiple times before the length of wstrades
reaches 30, the first couple of trades will be returned every time
getTrades() gets called. This can happen if a short period is used (e.g.
in trend_ema) and if the market is not very active and this doesn't make
sense to me.