### PR TITLE
fixing docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - '8'
   - '10'
   - '11'
 before_install:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM node:8 as builder
+FROM node:10 as builder
 ADD . /app
 WORKDIR /app
 RUN npm install -g node-gyp
 RUN npm install --unsafe
 
-FROM node:8-alpine
+FROM node:10-alpine
 
 ADD . /app
 WORKDIR /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,13 +16,15 @@ services:
       - "17365:17365"
     depends_on:
       - mongodb
+    links:
+      - mongodb
     environment:
       - MONGODB_PORT_27017_TCP_ADDR=mongodb
   mongodb:
     image: mongo:latest
     volumes:
       - ./database:/data/db
-    command: mongod --smallfiles --bind_ip=0.0.0.0 --logpath=/dev/null
+    command: mongod --bind_ip=0.0.0.0 --logpath=/dev/null
     expose:
       - 27017
 


### PR DESCRIPTION
fixes #1946 

* Use Node 10 in the Dockerfile
  * The dependency [talib](https://github.com/oransel/node-talib) is now initiazling the node module in a [context aware fashion](https://github.com/oransel/node-talib/blob/master/src/talib.cpp#L1085), this api is only available in node > 10
* Remove node 8 from travis environments
* Use `mongodb` as a link in docker-compose, this way `mongodb` is available as a named host in the `server` service
* Remove `--smallfiles` flag from `mongod`, it appears this flag no longer exists.