### PR TITLE
Fix spontaneous simulator exits

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -27,6 +27,7 @@
     },
     "parserOptions": {
         "sourceType": "module",
+        "ecmaVersion": "2017",
         "ecmaFeatures": {
             "experimentalObjectRestSpread": true
         }


### PR DESCRIPTION
Fixes #1922 by calling `getNext()` based on record count checks rather than the unreliable `.on('end')` cursor event.