### PR TITLE
Add check to end simulation and add drain function properly

### DIFF
--- a/commands/sim.js
+++ b/commands/sim.js
@@ -295,6 +295,10 @@ module.exports = function (program, conf) {
           setImmediate(async () => await getNext())
         }
 
+        if(totalTrades === 0) {
+          onCollectionCursorEnd()
+        }
+
         collectionCursorStream.on('data', function(trade) {
           lastTrade = trade
           numTrades++

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -979,12 +979,12 @@ module.exports = function (s, conf) {
     update: onTrades,
     exit: function (cb) {
       if(tradeProcessingQueue.length()){
-        tradeProcessingQueue.drain = () => {
+        tradeProcessingQueue.drain(() => {
           if(s.strategy.onExit) {
             s.strategy.onExit.call( s.ctx, s )
           }
           cb()
-        }
+        })
       } else {
         if(s.strategy.onExit) {
           s.strategy.onExit.call( s.ctx, s )


### PR DESCRIPTION
Simulation ends unexpectedly without generating the final report and html file.
This is because onCollectionCursorEnd() should be called in order to generate the final report. Checking when the amount of trades from mongoDb is zero, you can call that function to get the report. I have created an issue  #1976.