### PR TITLE
making cexio exchange more resilient against duplicated/bad data

### DIFF
--- a/extensions/exchanges/cexio/exchange.js
+++ b/extensions/exchanges/cexio/exchange.js
@@ -281,6 +281,11 @@ module.exports = function cexio (conf) {
               side: trade.type
             }
           })
+          const maxTrade = _.maxBy(trades, 'trade_id')
+          if (maxTrade && (maxTrade.trade_id <= opts.from)) {
+            func_args[0].from = func_args[0].from + trades.length
+            return retry('getTrades', func_args)
+          }
           cb(null, trades)
         })
       } else { // WebSocket once Live


### PR DESCRIPTION
Fixes issue https://github.com/DeviaVir/zenbot/issues/1952

The Cex.io api has a few ranges where it will return the same exact data when using a different "from" or "since" parameter. For example, 375024 and 376024 return the same exact data. 

https://cex.io/api/trade_history/BTC/USD/?since=375024
and 
https://cex.io/api/trade_history/BTC/USD/?since=376024

This causes backfill to fail. This change increments the from when this happens to allow the backfill to continue and complete. 