### PR TITLE
Add notifications to ADAMANT Messenger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ gen.*.sh
 .env
 scripts/auto_backtester/backtesting_*.csv
 database/*
+.vscode/

--- a/conf-sample.js
+++ b/conf-sample.js
@@ -211,6 +211,23 @@ c.notifiers.slack.on = false
 c.notifiers.slack.webhook_url = ''
 // end slack config
 
+// ADAMANT Messenger config
+c.notifiers.adamant = {}
+c.notifiers.adamant.on = false
+c.notifiers.adamant.nodes = [
+  'https://endless.adamant.im',
+  'https://clown.adamant.im',
+  'https://bid.adamant.im',
+  'https://unusual.adamant.im',
+  'https://debate.adamant.im',
+  'http://185.231.245.26:36666',
+  'https://lake.adamant.im',
+  'http://localhost:36666'
+],
+c.notifiers.adamant.fromPassphrase = ''
+c.notifiers.adamant.toAddresses = ['']
+// end ADAMANT Messenger config
+
 // discord configs
 c.notifiers.discord = {}
 c.notifiers.discord.on = false // false discord disabled; true discord enabled (key should be correct)

--- a/docs/README.md
+++ b/docs/README.md
@@ -727,6 +727,11 @@ https://www.textbelt.com/
 Supply zenbot with your Telegram bot token and chat id zenbot will push notifications to your Telegram chat.
 https://telegram.org/
 
+### ADAMANT Messenger
+
+Supply Zenbot with recipients' ADM addresses, sender's account passPhrase and node list and Zenbot will push notifications to ADAMANT chats.
+https://adamant.im/
+
 ## Rest API
 
 You can enable a Rest API for Zenbot by enabling the following configuration

--- a/docs/notifiers/README.md
+++ b/docs/notifiers/README.md
@@ -48,3 +48,8 @@ https://pushover.net/
 
 Supply Zenbot with your Telegram bot token and chat id and Zenbot will push notifications to your Telegram chat.
 https://telegram.org/
+
+### ADAMANT Messenger
+
+Supply Zenbot with recipients' ADM addresses, sender's account passPhrase and node list and Zenbot will push notifications to ADAMANT chats.
+https://adamant.im/

--- a/extensions/notifiers/adamant.js
+++ b/extensions/notifiers/adamant.js
@@ -1,0 +1,15 @@
+module.exports = function adamant (config) {
+  const api = require('adamant-api')({passPhrase: config.fromPassphrase, node: config.nodes, logLevel: 'error'}, null)
+  var adamant = {
+    pushMessage: function(title, message) {
+      config.toAddresses.forEach(address => {
+        if (address) 
+          var result = api.send(config.fromPassphrase, address, title + ': ' + message, 'message')
+        if (!result.success) {
+          console.error(`Message to address ${address} was not accepted by ADAMANT node: ${result.error}.`)
+        }
+      })
+    }
+  }
+  return adamant
+}

--- a/package.json
+++ b/package.json
@@ -110,7 +110,8 @@
     "webpack-cli": "^3.0.4",
     "wexnz": "^0.1.3",
     "ws": "^7.1.0",
-    "zero-fill": "^2.2.3"
+    "zero-fill": "^2.2.3",
+    "adamant-api": "^0.5.1"
   },
   "devDependencies": {
     "eslint": "^4.19.1",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "wexnz": "^0.1.3",
     "ws": "^7.1.0",
     "zero-fill": "^2.2.3",
-    "adamant-api": "^0.5.1"
+    "adamant-api": "^0.5.2"
   },
   "devDependencies": {
     "eslint": "^4.19.1",


### PR DESCRIPTION
Notifications to decentralized blockchain messenger ADAMANT.

Params:
- `c.notifiers.adamant.fromPassphrase` is a passPhrase for sender's account like `cart angry pudding exhibit rule typical card image actress miracle ketchup shuffle`. Get new one on https://msg.adamant.im/. Be sure sender's account is not empty, get free tokens in the app.
- `c.notifiers.adamant.toAddresses` is an array of ADM addresses who will receive notifications. Example: `['U15744811633756100864', 'U7553468023140142965']`. They should be not empty also as their public keys should be known to the blockchain.
- `c.notifiers.adamant.nodes` is a list of ADAMANT nodes app may use to send notifications. Keep them default or run your own node.
