### PR TITLE
Update value for hitbtc BTCUSD

### DIFF
--- a/extensions/exchanges/hitbtc/products.json
+++ b/extensions/exchanges/hitbtc/products.json
@@ -8,10 +8,10 @@
   },
   {
     "asset": "BTC",
-    "currency": "USDT",
-    "min_size": 0.01,
-    "increment": "0.010000000000000000",
-    "label": "BTC/USDT"
+    "currency": "USD",
+    "min_size": 0.001,
+    "increment": "0.00001",
+    "label": "BTC/USD"
   },
   {
     "asset": "DASH",


### PR DESCRIPTION
After i solve this issue #2172 

The value for BTC-USD (ex USDT) was not good or not good anymore

Min_size was too high and increment was to high
For some reason in Hitbtc the currency for BTC-USDT on the web site is different in the API it's BTC-USD