### PR TITLE
add buy volumized percent

### DIFF
--- a/commands/trade.js
+++ b/commands/trade.js
@@ -33,6 +33,7 @@ module.exports = function (program, conf) {
     .option('--asset_capital <amount>', 'for paper trading, amount of start capital in asset', Number, conf.asset_capital)
     .option('--avg_slippage_pct <pct>', 'avg. amount of slippage to apply to paper trades', Number, conf.avg_slippage_pct)
     .option('--buy_pct <pct>', 'buy with this % of currency balance', Number, conf.buy_pct)
+    .option('--buy_volume_pct', 'buy % proportional to average running trade volume', Boolean, false)
     .option('--deposit <amt>', 'absolute initial capital (in currency) at the bots disposal (previously --buy_max_amt)', Number, conf.deposit)
     .option('--sell_pct <pct>', 'sell with this % of asset balance', Number, conf.sell_pct)
     .option('--markdown_buy_pct <pct>', '% to mark down buy price', Number, conf.markdown_buy_pct)
@@ -102,6 +103,7 @@ module.exports = function (program, conf) {
       var engine = engineFactory(s, conf)
       var collectionServiceInstance = collectionService(conf)
       if (!so.min_periods) so.min_periods = 1
+      if (so.buy_volume_pct) so.min_periods = 300
 
       const keyMap = new Map()
       keyMap.set('b', 'limit'.grey + ' BUY'.green)
@@ -578,6 +580,7 @@ module.exports = function (program, conf) {
       })
 
       var prev_timeout = null
+      
       function forwardScan () {
         function saveSession () {
           engine.syncBalance(function (err) {

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -401,6 +401,29 @@ module.exports = function (s, conf) {
 
         if (is_reorder) {
           buy_pct = reorder_pct
+        } else if (so.buy_volume_pct) {
+          function calculateVolumeAverage(volumes) {
+            return volumes.reduce((x,y) => x + y, 0) / volumes.length
+          }
+
+          const fiveMinutesAgo = new Date().getMinutes(new Date().getMinutes() - 5);
+          const fiveMinutesVolumes = s.lookback.filter(_ => _.close_time > fiveMinutesAgo).map(_ => _.volume);
+          const subjectVolume = calculateVolumeAverage([calculateVolumeAverage(fiveMinutesVolumes), s.period.volume])
+
+          const oneDayAgo = new Date().setDate(new Date().getDate() - 1);
+          const oneDayVolumes = s.lookback.filter(_ => _.close_time > oneDayAgo).map(_ => _.volume);
+          const volumeAverage = calculateVolumeAverage(oneDayVolumes);
+          const capacity = volumeAverage * 2;
+
+          const buy_volume_pct = Math.round((subjectVolume / capacity) * so.buy_pct);
+          
+          console.log("current period volume:", s.period.volume)
+          console.log("subject volume:", subjectVolume)
+          console.log("volume average:", volumeAverage);
+          console.log("capacity:", capacity)
+          console.log("buy percent:", buy_volume_pct)
+
+          buy_pct = Math.min(Math.abs(buy_volume_pct), 99);
         } else {
           buy_pct = so.buy_pct
         }


### PR DESCRIPTION
I added an option to buy based on a 24 hour running volume average calculation. It is as follows:

(((5min_avg + volume)/2) /  24hr_avg * 2) * buy_pct