### PR TITLE
Update trade cursor to next interval on empty trade result

### DIFF
--- a/commands/trade.js
+++ b/commands/trade.js
@@ -744,6 +744,7 @@ module.exports = function (program, conf) {
             })
           }
           else {
+            trade_cursor += parseInt(so.poll_trades)
             saveSession()
           }
         })


### PR DESCRIPTION
Currently, zenbot halts if zero trades came back from trade polling, as the `getTrades()` options' `from` is never updated. Impact: The displayed current time is never updated, while `getTrades()` keeps fetching the same empty result set. The bot looks as if it's frozen while its stats row keeps blinking.

Empty trade arrays may come back from `getTrades()` if either:
- Volume is low, or
- The `--poll_trades` parameter is set low, making an empty result set likely.

This PR fixes that, by incrementing the trade cursor by the `poll_trades` value, making sure next `getTrades()` call requests newer trades, if any.