### PR TITLE
Stop zenbot from stalling when getTrades is slow

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -909,9 +909,6 @@ module.exports = function (s, conf) {
   }
 
   function onTrade(trade, is_preroll, cb) {
-    if (s.period && trade.time < s.period.time) {
-      return
-    }
     var day = (new Date(trade.time)).getDate()
     if (s.last_day && day !== s.last_day) {
       s.day_count++


### PR DESCRIPTION
`onTrade()` in `engine.js` was returning out of execution immediately when an incoming trade was older than the last known trade. This may occur when an exchange API call response is slower than `poll_trades`. By returning immediately out of `onTrade`, further incrementing the trade cursor is prevented, causing the bot to stay stuck in the same time stamp.

Removing the return statement entirely, because further down the function, the incoming trade's timestamp is already being checked before adding it. This way, zenbot resumes operation when an older-than-last trade comes in.

I welcome any feedback on this, as it's hard to know as a contributor what the design thinking behind this was originally.