### PR TITLE
Restore onTrade() bail-out in a way that works

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -909,6 +909,9 @@ module.exports = function (s, conf) {
   }
 
   function onTrade(trade, is_preroll, cb) {
+    if (s.period && trade.time < s.period.time) {
+      return cb()
+    }
     var day = (new Date(trade.time)).getDate()
     if (s.last_day && day !== s.last_day) {
       s.day_count++


### PR DESCRIPTION
This fix undoes #2334 and fixes the problem it tried to fix, the right way, by restoring bailing out of onTrade when an old trade comes in, but this time with the call to the callback function which went missing in the changes in https://github.com/DeviaVir/zenbot/commit/17e9758eb0c2179ee81a960ffd83bcb54012c025#diff-a41b519e7979a713e894ef8d1b3fe568R347-R349 .

Because of the missing call on the callback function, the async event queue loop would break when an old trade came in. This PR restores resuming operations when a trade comes in that belongs to a previous period.

The bug, and these changes, affect only those running paper or live trading in very short timeframes such as 1s or 5s.