### PR TITLE
Fix: use lolex only for setTimeout function to avoid mongodb to stall

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -758,7 +758,14 @@ module.exports = function (s, conf) {
   }
 
   function withOnPeriod (trade, period_id, cb) {
-    if (!clock && so.mode !== 'live' && so.mode !== 'paper') clock = lolex.install({ shouldAdvanceTime: false, now: trade.time })
+    if (!clock && so.mode !== 'live' && so.mode !== 'paper') clock = lolex.install(
+      {
+        shouldAdvanceTime: false,
+        now: trade.time,
+        toFake: [
+          'setTimeout'
+        ]
+      })
 
     updatePeriod(trade)
     if (!s.in_preroll) {
@@ -776,7 +783,7 @@ module.exports = function (s, conf) {
             clock.tick(5000)
             diff -= 5000
           }
-          clock.tick(diff)
+          clock.tick(diff < 0 ? 1 : diff)
         }
 
         if (s.signal) {


### PR DESCRIPTION
Basically since version 3.6.2 mongodb library has replaced processWaitQueue with setImmediate.

lolex.install() is monkey patching setImmediate which is causing mongodb library to stall.

Here you can see more details about this:

https://github.com/mongodb/node-mongodb-native/pull/2537

https://github.com/Automattic/mongoose/issues/9417

So, in order to solve the problem we will only use lolex for setTimeout and not for other clock methods.

It fixes: https://github.com/DeviaVir/zenbot/issues/2412#issuecomment-705963100