### PR TITLE
Set correct _id when saving trade during paper/live mode

### DIFF
--- a/commands/trade.js
+++ b/commands/trade.js
@@ -750,6 +750,7 @@ module.exports = function (program, conf) {
         })
         function saveTrade (trade) {
           trade.id = so.selector.normalized + '-' + String(trade.trade_id)
+          trade._id = trade.id
           trade.selector = so.selector.normalized
           if (!marker.from) {
             marker.from = trade_cursor


### PR DESCRIPTION
Before, zenbot would store trades from the paper/live `trade.js` command without setting an `_id`, causing trades to be assigned a random Mongo document ID, causing the database not to detect duplicate trades, therefore growing the database unnecessarily, and probably also corrupt volume calculations (#1851).

With this fix, trades as part of trade/live mode, are assigned the correct unique ID in the format of, for example, `binance.ETH-USDT-74209857039`.