### PR TITLE
Update file for last version on ubuntu 20.04

### DIFF
--- a/docs/installation/debian-ubuntu.md
+++ b/docs/installation/debian-ubuntu.md
@@ -1,14 +1,16 @@
 #### Debian-based OSes (complete guide)
 
-Although this guide was initially created for Ubuntu 16.04, it is reported to also work on newer Ubuntu versions and Debian.
+Although this guide was initially created for Ubuntu 20.04, Also works with Debian.
 
 ```
-curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
+sudo apt-get install curl python2 git build-essential mongodb nodejs
+
+curl -sL https://deb.nodesource.com/setup_15.x | sudo -E bash -
 
 sudo apt-get update
 sudo apt-get upgrade -y
 
-sudo apt-get install -y git build-essential mongodb nodejs
+sudo apt-get install curl python2 git build-essential mongodb nodejs
 
 git clone https://github.com/deviavir/zenbot.git
 cd zenbot


### PR DESCRIPTION
This update will allow Ubuntu 20.04 users to use Zenbot, indeed in the latest version Ubuntu python 2 is not installed by default.