### PR TITLE
Fix docker, remove public open MongoDB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ RUN chown -R node:node /app
 COPY --chown=node . /app
 COPY --chown=node --from=builder /usr/local/lib/node_modules/ /usr/local/lib/node_modules/
 COPY --chown=node --from=builder /app/node_modules /app/node_modules/
-COPY --chown=node --from=builder /app/dist /app/dist/
 
 USER node
 ENV NODE_ENV production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,6 @@ services:
     volumes:
       - ./database:/data/db
     command: mongod --bind_ip=0.0.0.0 --logpath=/dev/null
-    expose:
-      - 27017
   # Remove below comments to use this container. "adminMongo is a Web based user interface (GUI) to handle all your MongoDB connections/databases needs."
   #
   #adminmongo:


### PR DESCRIPTION
There are no dist files built, so they cannot be copied. This fixes the current docker issues.
Also I removed the public open MongoDB. It is enough if it is just reachable for zenbot through the docker networking.