### PR TITLE
Update exchange.js

### DIFF
--- a/extensions/exchanges/binance/exchange.js
+++ b/extensions/exchanges/binance/exchange.js
@@ -184,7 +184,6 @@ module.exports = function binance (conf) {
       opts.type = 'limit'
       var args = {}
       if (opts.order_type === 'taker') {
-        delete opts.price
         delete opts.post_only
         opts.type = 'market'
       } else {
@@ -240,7 +239,6 @@ module.exports = function binance (conf) {
       opts.type = 'limit'
       var args = {}
       if (opts.order_type === 'taker') {
-        delete opts.price
         delete opts.post_only
         opts.type = 'market'
       } else {


### PR DESCRIPTION
Fixes zenbot for not being able to place buy/sell orders while using the 'taker' mode. The binance api requires a price else it returns with an error:

An error occurred { InvalidOrder: binance createOrder method requires a price argument for a limit order
    at binance.createOrder (/home/papi/Desktop/zenbot/node_modules/ccxt/js/binance.js:1724:23) constructor: [Function: InvalidOrder], name: 'InvalidOrder' }

Binance API is down! unable to call buy, retrying in 20s
[ { size: '1985.55367709',
    fee: null,
    orig_size: '1985.55367709',
    remaining_size: '1985.55367709',
    orig_price: '0.00000026',
    cancel_after: 'day',
    product_id: 'DOGE-BTC',
    type: 'limit',
    side: 'buy',
    post_only: true } ]