### PR TITLE
Fixing simulations for Kraken exchange

### DIFF
--- a/extensions/exchanges/kraken/exchange.js
+++ b/extensions/exchanges/kraken/exchange.js
@@ -39,10 +39,34 @@ module.exports = function container(conf) {
     var asset = product_id.split('-')[0]
     var currency = product_id.split('-')[1]
 
-    var assetsToFix = ['BCH', 'DASH', 'EOS', 'GNO']
-    if (assetsToFix.indexOf(asset) >= 0 && currency.length > 3) {
-      currency = currency.substring(1)
+    var fixMap = {
+      'XETH': 'ETH',
+      'XXBT': 'XBT',
+      'XLTC': 'LTC',
+      'XXDG': 'XDG',
+      'XETC': 'ETC',
+      'XMLN': 'MLN',
+      'XREP': 'REP',
+      'XXRP': 'XRP',
+      'XXLM': 'XLM',
+      'XXMR': 'XMR',
+      'XZEC': 'ZEC',
+      'ZAUD': 'AUD',
+      'ZEUR': 'EUR',
+      'ZGBP': 'GBP',
+      'ZUSD': 'USD',
+      'ZJPY': 'JPY',
+      'ZCAD': 'CAD',
     }
+
+    if (asset in fixMap) {
+      asset = fixMap[asset]
+    }
+
+    if (currency in fixMap) {
+      currency = fixMap[currency]
+    }
+
     return asset + currency
   }
 

--- a/extensions/exchanges/kraken/products.json
+++ b/extensions/exchanges/kraken/products.json
@@ -2,1982 +2,1982 @@
   {
     "asset": "AAVE",
     "currency": "ZAUD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.1000000000",
+    "increment": "0.0100000000",
     "label": "AAVE/AUD"
   },
   {
     "asset": "AAVE",
     "currency": "XETH",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.0500000000",
+    "increment": "0.0001000000",
     "label": "AAVE/ETH"
   },
   {
     "asset": "AAVE",
     "currency": "ZEUR",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.0500000000",
+    "increment": "0.0100000000",
     "label": "AAVE/EUR"
   },
   {
     "asset": "AAVE",
     "currency": "ZGBP",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.0500000000",
+    "increment": "0.0100000000",
     "label": "AAVE/GBP"
   },
   {
     "asset": "AAVE",
     "currency": "ZUSD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.0500000000",
+    "increment": "0.0100000000",
     "label": "AAVE/USD"
   },
   {
     "asset": "AAVE",
     "currency": "XXBT",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.0500000000",
+    "increment": "0.0000010000",
     "label": "AAVE/XBT"
   },
   {
     "asset": "ADA",
     "currency": "ZAUD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "25.0000000000",
+    "increment": "0.0000100000",
     "label": "ADA/AUD"
   },
   {
     "asset": "ADA",
     "currency": "XETH",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "25.0000000000",
+    "increment": "0.0000001000",
     "label": "ADA/ETH"
   },
   {
     "asset": "ADA",
     "currency": "ZEUR",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "25.0000000000",
+    "increment": "0.0000010000",
     "label": "ADA/EUR"
   },
   {
     "asset": "ADA",
     "currency": "ZGBP",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "25.0000000000",
+    "increment": "0.0000100000",
     "label": "ADA/GBP"
   },
   {
     "asset": "ADA",
     "currency": "ZUSD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "25.0000000000",
+    "increment": "0.0000010000",
     "label": "ADA/USD"
   },
   {
     "asset": "ADA",
     "currency": "USDT",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "25.0000000000",
+    "increment": "0.0000010000",
     "label": "ADA/USDT"
   },
   {
     "asset": "ADA",
     "currency": "XXBT",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "25.0000000000",
+    "increment": "0.0000000100",
     "label": "ADA/XBT"
   },
   {
     "asset": "ALGO",
     "currency": "XETH",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "15.0000000000",
+    "increment": "0.0000001000",
     "label": "ALGO/ETH"
   },
   {
     "asset": "ALGO",
     "currency": "ZEUR",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "15.0000000000",
+    "increment": "0.0000100000",
     "label": "ALGO/EUR"
   },
   {
     "asset": "ALGO",
     "currency": "ZGBP",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "15.0000000000",
+    "increment": "0.0000100000",
     "label": "ALGO/GBP"
   },
   {
     "asset": "ALGO",
     "currency": "ZUSD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "15.0000000000",
+    "increment": "0.0000100000",
     "label": "ALGO/USD"
   },
   {
     "asset": "ALGO",
     "currency": "XXBT",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "15.0000000000",
+    "increment": "0.0000000100",
     "label": "ALGO/XBT"
   },
   {
     "asset": "ANT",
     "currency": "XETH",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "2.0000000000",
+    "increment": "0.0000010000",
     "label": "ANT/ETH"
   },
   {
     "asset": "ANT",
     "currency": "ZEUR",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "2.0000000000",
+    "increment": "0.0001000000",
     "label": "ANT/EUR"
   },
   {
     "asset": "ANT",
     "currency": "ZUSD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "2.0000000000",
+    "increment": "0.0001000000",
     "label": "ANT/USD"
   },
   {
     "asset": "ANT",
     "currency": "XXBT",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "2.0000000000",
+    "increment": "0.0000000100",
     "label": "ANT/XBT"
   },
   {
     "asset": "ATOM",
     "currency": "ZAUD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "1.0000000000",
+    "increment": "0.0001000000",
     "label": "ATOM/AUD"
   },
   {
     "asset": "ATOM",
     "currency": "XETH",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "1.0000000000",
+    "increment": "0.0000010000",
     "label": "ATOM/ETH"
   },
   {
     "asset": "ATOM",
     "currency": "ZEUR",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "1.0000000000",
+    "increment": "0.0001000000",
     "label": "ATOM/EUR"
   },
   {
     "asset": "ATOM",
     "currency": "ZGBP",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "1.0000000000",
+    "increment": "0.0001000000",
     "label": "ATOM/GBP"
   },
   {
     "asset": "ATOM",
     "currency": "ZUSD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "1.0000000000",
+    "increment": "0.0001000000",
     "label": "ATOM/USD"
   },
   {
     "asset": "ATOM",
     "currency": "XXBT",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "1.0000000000",
+    "increment": "0.0000001000",
     "label": "ATOM/XBT"
   },
   {
     "asset": "ZAUD",
     "currency": "ZJPY",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "10.0000000000",
+    "increment": "0.0010000000",
     "label": "AUD/JPY"
   },
   {
     "asset": "ZAUD",
     "currency": "ZUSD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "10.0000000000",
+    "increment": "0.0000100000",
     "label": "AUD/USD"
   },
   {
     "asset": "BAL",
     "currency": "XETH",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.3000000000",
+    "increment": "0.0000100000",
     "label": "BAL/ETH"
   },
   {
     "asset": "BAL",
     "currency": "ZEUR",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.3000000000",
+    "increment": "0.0100000000",
     "label": "BAL/EUR"
   },
   {
     "asset": "BAL",
     "currency": "ZUSD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.3000000000",
+    "increment": "0.0100000000",
     "label": "BAL/USD"
   },
   {
     "asset": "BAL",
     "currency": "XXBT",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.3000000000",
+    "increment": "0.0000010000",
     "label": "BAL/XBT"
   },
   {
     "asset": "BAT",
     "currency": "XETH",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "30.0000000000",
+    "increment": "0.0000001000",
     "label": "BAT/ETH"
   },
   {
     "asset": "BAT",
     "currency": "ZEUR",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "30.0000000000",
+    "increment": "0.0000100000",
     "label": "BAT/EUR"
   },
   {
     "asset": "BAT",
     "currency": "ZUSD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "30.0000000000",
+    "increment": "0.0000100000",
     "label": "BAT/USD"
   },
   {
     "asset": "BAT",
     "currency": "XXBT",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "30.0000000000",
+    "increment": "0.0000000100",
     "label": "BAT/XBT"
   },
   {
     "asset": "BCH",
     "currency": "ZAUD",
-    "min_size": "0.002",
-    "increment": "0.00010000",
+    "min_size": "0.0200000000",
+    "increment": "0.0100000000",
     "label": "BCH/AUD"
   },
   {
     "asset": "BCH",
     "currency": "XETH",
-    "min_size": "0.002",
-    "increment": "0.00010000",
+    "min_size": "0.0200000000",
+    "increment": "0.0001000000",
     "label": "BCH/ETH"
   },
   {
     "asset": "BCH",
     "currency": "ZEUR",
-    "min_size": "0.002",
-    "increment": "0.00010000",
+    "min_size": "0.0200000000",
+    "increment": "0.0100000000",
     "label": "BCH/EUR"
   },
   {
     "asset": "BCH",
     "currency": "ZGBP",
-    "min_size": "0.002",
-    "increment": "0.00010000",
+    "min_size": "0.0200000000",
+    "increment": "0.0100000000",
     "label": "BCH/GBP"
   },
   {
     "asset": "BCH",
     "currency": "ZJPY",
-    "min_size": "0.002",
-    "increment": "0.00010000",
+    "min_size": "0.0200000000",
+    "increment": "1.0000000000",
     "label": "BCH/JPY"
   },
   {
     "asset": "BCH",
     "currency": "ZUSD",
-    "min_size": "0.002",
-    "increment": "0.00010000",
+    "min_size": "0.0200000000",
+    "increment": "0.0100000000",
     "label": "BCH/USD"
   },
   {
     "asset": "BCH",
     "currency": "USDT",
-    "min_size": "0.002",
-    "increment": "0.00010000",
+    "min_size": "0.0200000000",
+    "increment": "0.0100000000",
     "label": "BCH/USDT"
   },
   {
     "asset": "BCH",
     "currency": "XXBT",
-    "min_size": "0.002",
-    "increment": "0.00010000",
+    "min_size": "0.0200000000",
+    "increment": "0.0000100000",
     "label": "BCH/XBT"
   },
   {
     "asset": "COMP",
     "currency": "XETH",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.0500000000",
+    "increment": "0.0001000000",
     "label": "COMP/ETH"
   },
   {
     "asset": "COMP",
     "currency": "ZEUR",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.0500000000",
+    "increment": "0.0100000000",
     "label": "COMP/EUR"
   },
   {
     "asset": "COMP",
     "currency": "ZUSD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.0500000000",
+    "increment": "0.0100000000",
     "label": "COMP/USD"
   },
   {
     "asset": "COMP",
     "currency": "XXBT",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.0500000000",
+    "increment": "0.0000010000",
     "label": "COMP/XBT"
   },
   {
     "asset": "CRV",
     "currency": "XETH",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "10.0000000000",
+    "increment": "0.0000010000",
     "label": "CRV/ETH"
   },
   {
     "asset": "CRV",
     "currency": "ZEUR",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "10.0000000000",
+    "increment": "0.0010000000",
     "label": "CRV/EUR"
   },
   {
     "asset": "CRV",
     "currency": "ZUSD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "10.0000000000",
+    "increment": "0.0010000000",
     "label": "CRV/USD"
   },
   {
     "asset": "CRV",
     "currency": "XXBT",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "10.0000000000",
+    "increment": "0.0000001000",
     "label": "CRV/XBT"
   },
   {
     "asset": "DAI",
     "currency": "ZEUR",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "5.0000000000",
+    "increment": "0.0000100000",
     "label": "DAI/EUR"
   },
   {
     "asset": "DAI",
     "currency": "ZUSD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "5.0000000000",
+    "increment": "0.0000100000",
     "label": "DAI/USD"
   },
   {
     "asset": "DAI",
     "currency": "USDT",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "5.0000000000",
+    "increment": "0.0000100000",
     "label": "DAI/USDT"
   },
   {
     "asset": "DASH",
     "currency": "ZEUR",
-    "min_size": "0.03",
-    "increment": "0.00010000",
+    "min_size": "0.0500000000",
+    "increment": "0.0010000000",
     "label": "DASH/EUR"
   },
   {
     "asset": "DASH",
     "currency": "ZUSD",
-    "min_size": "0.03",
-    "increment": "0.00010000",
+    "min_size": "0.0500000000",
+    "increment": "0.0010000000",
     "label": "DASH/USD"
   },
   {
     "asset": "DASH",
     "currency": "XXBT",
-    "min_size": "0.03",
-    "increment": "0.00010000",
+    "min_size": "0.0500000000",
+    "increment": "0.0000100000",
     "label": "DASH/XBT"
   },
   {
     "asset": "DOT",
     "currency": "ZAUD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.5000000000",
+    "increment": "0.0001000000",
     "label": "DOT/AUD"
   },
   {
     "asset": "DOT",
     "currency": "XETH",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.5000000000",
+    "increment": "0.0000010000",
     "label": "DOT/ETH"
   },
   {
     "asset": "DOT",
     "currency": "ZEUR",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.5000000000",
+    "increment": "0.0001000000",
     "label": "DOT/EUR"
   },
   {
     "asset": "DOT",
     "currency": "ZGBP",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.5000000000",
+    "increment": "0.0001000000",
     "label": "DOT/GBP"
   },
   {
     "asset": "DOT",
     "currency": "ZUSD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.5000000000",
+    "increment": "0.0001000000",
     "label": "DOT/USD"
   },
   {
     "asset": "DOT",
     "currency": "USDT",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.5000000000",
+    "increment": "0.0001000000",
     "label": "DOT/USDT"
   },
   {
     "asset": "DOT",
     "currency": "XXBT",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.5000000000",
+    "increment": "0.0000000100",
     "label": "DOT/XBT"
   },
   {
     "asset": "EOS",
     "currency": "XETH",
-    "min_size": "3.0",
-    "increment": "0.00010000",
+    "min_size": "2.5000000000",
+    "increment": "0.0000010000",
     "label": "EOS/ETH"
   },
   {
     "asset": "EOS",
     "currency": "ZEUR",
-    "min_size": "3.0",
-    "increment": "0.00010000",
+    "min_size": "2.5000000000",
+    "increment": "0.0001000000",
     "label": "EOS/EUR"
   },
   {
     "asset": "EOS",
     "currency": "ZUSD",
-    "min_size": "3.0",
-    "increment": "0.00010000",
+    "min_size": "2.5000000000",
+    "increment": "0.0001000000",
     "label": "EOS/USD"
   },
   {
     "asset": "EOS",
     "currency": "USDT",
-    "min_size": "3.0",
-    "increment": "0.00010000",
+    "min_size": "2.5000000000",
+    "increment": "0.0001000000",
     "label": "EOS/USDT"
   },
   {
     "asset": "EOS",
     "currency": "XXBT",
-    "min_size": "3.0",
-    "increment": "0.00010000",
+    "min_size": "2.5000000000",
+    "increment": "0.0000001000",
     "label": "EOS/XBT"
   },
   {
     "asset": "ETH2.S",
     "currency": "XETH",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.0200000000",
+    "increment": "0.0001000000",
     "label": "ETH2.S/ETH"
   },
   {
     "asset": "XETH",
     "currency": "ZAUD",
-    "min_size": "0.02",
-    "increment": "0.00010000",
+    "min_size": "0.0050000000",
+    "increment": "0.0100000000",
     "label": "ETH/AUD"
   },
   {
     "asset": "XETH",
     "currency": "CHF",
-    "min_size": "0.02",
-    "increment": "0.00010000",
+    "min_size": "0.0050000000",
+    "increment": "0.0100000000",
     "label": "ETH/CHF"
   },
   {
     "asset": "XETH",
     "currency": "DAI",
-    "min_size": "0.02",
-    "increment": "0.00010000",
+    "min_size": "0.0050000000",
+    "increment": "0.0010000000",
     "label": "ETH/DAI"
   },
   {
     "asset": "XETH",
     "currency": "USDC",
-    "min_size": "0.02",
-    "increment": "0.00010000",
+    "min_size": "0.0050000000",
+    "increment": "0.0100000000",
     "label": "ETH/USDC"
   },
   {
     "asset": "XETH",
     "currency": "USDT",
-    "min_size": "0.02",
-    "increment": "0.00010000",
+    "min_size": "0.0050000000",
+    "increment": "0.0100000000",
     "label": "ETH/USDT"
   },
   {
     "asset": "ZEUR",
     "currency": "ZAUD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "5.0000000000",
+    "increment": "0.0000100000",
     "label": "EUR/AUD"
   },
   {
     "asset": "ZEUR",
     "currency": "ZCAD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "5.0000000000",
+    "increment": "0.0000100000",
     "label": "EUR/CAD"
   },
   {
     "asset": "ZEUR",
     "currency": "CHF",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "5.0000000000",
+    "increment": "0.0000100000",
     "label": "EUR/CHF"
   },
   {
     "asset": "ZEUR",
     "currency": "ZGBP",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "5.0000000000",
+    "increment": "0.0000100000",
     "label": "EUR/GBP"
   },
   {
     "asset": "ZEUR",
     "currency": "ZJPY",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "5.0000000000",
+    "increment": "0.0010000000",
     "label": "EUR/JPY"
   },
   {
     "asset": "FIL",
     "currency": "ZAUD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.3000000000",
+    "increment": "0.0010000000",
     "label": "FIL/AUD"
   },
   {
     "asset": "FIL",
     "currency": "XETH",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.3000000000",
+    "increment": "0.0000100000",
     "label": "FIL/ETH"
   },
   {
     "asset": "FIL",
     "currency": "ZEUR",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.3000000000",
+    "increment": "0.0010000000",
     "label": "FIL/EUR"
   },
   {
     "asset": "FIL",
     "currency": "ZGBP",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.3000000000",
+    "increment": "0.0010000000",
     "label": "FIL/GBP"
   },
   {
     "asset": "FIL",
     "currency": "ZUSD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.3000000000",
+    "increment": "0.0010000000",
     "label": "FIL/USD"
   },
   {
     "asset": "FIL",
     "currency": "XXBT",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.3000000000",
+    "increment": "0.0000001000",
     "label": "FIL/XBT"
   },
   {
     "asset": "FLOW",
     "currency": "XETH",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "1.0000000000",
+    "increment": "0.0000100000",
     "label": "FLOW/ETH"
   },
   {
     "asset": "FLOW",
     "currency": "ZEUR",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "1.0000000000",
+    "increment": "0.0010000000",
     "label": "FLOW/EUR"
   },
   {
     "asset": "FLOW",
     "currency": "ZGBP",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "1.0000000000",
+    "increment": "0.0010000000",
     "label": "FLOW/GBP"
   },
   {
     "asset": "FLOW",
     "currency": "ZUSD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "1.0000000000",
+    "increment": "0.0010000000",
     "label": "FLOW/USD"
   },
   {
     "asset": "FLOW",
     "currency": "XXBT",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "1.0000000000",
+    "increment": "0.0000001000",
     "label": "FLOW/XBT"
   },
   {
     "asset": "GNO",
     "currency": "XETH",
-    "min_size": "0.03",
-    "increment": "0.00010000",
+    "min_size": "0.0500000000",
+    "increment": "0.0001000000",
     "label": "GNO/ETH"
   },
   {
     "asset": "GNO",
     "currency": "ZEUR",
-    "min_size": "0.03",
-    "increment": "0.00010000",
+    "min_size": "0.0500000000",
+    "increment": "0.0100000000",
     "label": "GNO/EUR"
   },
   {
     "asset": "GNO",
     "currency": "ZUSD",
-    "min_size": "0.03",
-    "increment": "0.00010000",
+    "min_size": "0.0500000000",
+    "increment": "0.0100000000",
     "label": "GNO/USD"
   },
   {
     "asset": "GNO",
     "currency": "XXBT",
-    "min_size": "0.03",
-    "increment": "0.00010000",
+    "min_size": "0.0500000000",
+    "increment": "0.0000100000",
     "label": "GNO/XBT"
   },
   {
     "asset": "GRT",
     "currency": "ZAUD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "20.0000000000",
+    "increment": "0.0000100000",
     "label": "GRT/AUD"
   },
   {
     "asset": "GRT",
     "currency": "XETH",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "20.0000000000",
+    "increment": "0.0000001000",
     "label": "GRT/ETH"
   },
   {
     "asset": "GRT",
     "currency": "ZEUR",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "20.0000000000",
+    "increment": "0.0000100000",
     "label": "GRT/EUR"
   },
   {
     "asset": "GRT",
     "currency": "ZGBP",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "20.0000000000",
+    "increment": "0.0000100000",
     "label": "GRT/GBP"
   },
   {
     "asset": "GRT",
     "currency": "ZUSD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "20.0000000000",
+    "increment": "0.0000100000",
     "label": "GRT/USD"
   },
   {
     "asset": "GRT",
     "currency": "XXBT",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "20.0000000000",
+    "increment": "0.0000000100",
     "label": "GRT/XBT"
   },
   {
     "asset": "ICX",
     "currency": "XETH",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "10.0000000000",
+    "increment": "0.0000001000",
     "label": "ICX/ETH"
   },
   {
     "asset": "ICX",
     "currency": "ZEUR",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "10.0000000000",
+    "increment": "0.0001000000",
     "label": "ICX/EUR"
   },
   {
     "asset": "ICX",
     "currency": "ZUSD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "10.0000000000",
+    "increment": "0.0001000000",
     "label": "ICX/USD"
   },
   {
     "asset": "ICX",
     "currency": "XXBT",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "10.0000000000",
+    "increment": "0.0000000100",
     "label": "ICX/XBT"
   },
   {
     "asset": "KAVA",
     "currency": "XETH",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "5.0000000000",
+    "increment": "0.0000010000",
     "label": "KAVA/ETH"
   },
   {
     "asset": "KAVA",
     "currency": "ZEUR",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "5.0000000000",
+    "increment": "0.0001000000",
     "label": "KAVA/EUR"
   },
   {
     "asset": "KAVA",
     "currency": "ZUSD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "5.0000000000",
+    "increment": "0.0001000000",
     "label": "KAVA/USD"
   },
   {
     "asset": "KAVA",
     "currency": "XXBT",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "5.0000000000",
+    "increment": "0.0000000100",
     "label": "KAVA/XBT"
   },
   {
     "asset": "KEEP",
     "currency": "XETH",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "25.0000000000",
+    "increment": "0.0000001000",
     "label": "KEEP/ETH"
   },
   {
     "asset": "KEEP",
     "currency": "ZEUR",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "25.0000000000",
+    "increment": "0.0000100000",
     "label": "KEEP/EUR"
   },
   {
     "asset": "KEEP",
     "currency": "ZUSD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "25.0000000000",
+    "increment": "0.0000100000",
     "label": "KEEP/USD"
   },
   {
     "asset": "KEEP",
     "currency": "XXBT",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "25.0000000000",
+    "increment": "0.0000000100",
     "label": "KEEP/XBT"
   },
   {
     "asset": "KNC",
     "currency": "XETH",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "5.0000000000",
+    "increment": "0.0000010000",
     "label": "KNC/ETH"
   },
   {
     "asset": "KNC",
     "currency": "ZEUR",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "5.0000000000",
+    "increment": "0.0001000000",
     "label": "KNC/EUR"
   },
   {
     "asset": "KNC",
     "currency": "ZUSD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "5.0000000000",
+    "increment": "0.0001000000",
     "label": "KNC/USD"
   },
   {
     "asset": "KNC",
     "currency": "XXBT",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "5.0000000000",
+    "increment": "0.0000000100",
     "label": "KNC/XBT"
   },
   {
     "asset": "KSM",
     "currency": "ZAUD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.1000000000",
+    "increment": "0.0100000000",
     "label": "KSM/AUD"
   },
   {
     "asset": "KSM",
     "currency": "XETH",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.1000000000",
+    "increment": "0.0000100000",
     "label": "KSM/ETH"
   },
   {
     "asset": "KSM",
     "currency": "ZEUR",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.1000000000",
+    "increment": "0.0100000000",
     "label": "KSM/EUR"
   },
   {
     "asset": "KSM",
     "currency": "ZGBP",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.1000000000",
+    "increment": "0.0100000000",
     "label": "KSM/GBP"
   },
   {
     "asset": "KSM",
     "currency": "ZUSD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.1000000000",
+    "increment": "0.0100000000",
     "label": "KSM/USD"
   },
   {
     "asset": "KSM",
     "currency": "XXBT",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.1000000000",
+    "increment": "0.0000010000",
     "label": "KSM/XBT"
   },
   {
     "asset": "LINK",
     "currency": "ZAUD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.5000000000",
+    "increment": "0.0010000000",
     "label": "LINK/AUD"
   },
   {
     "asset": "LINK",
     "currency": "XETH",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.5000000000",
+    "increment": "0.0000000100",
     "label": "LINK/ETH"
   },
   {
     "asset": "LINK",
     "currency": "ZEUR",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.5000000000",
+    "increment": "0.0000100000",
     "label": "LINK/EUR"
   },
   {
     "asset": "LINK",
     "currency": "ZGBP",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.5000000000",
+    "increment": "0.0010000000",
     "label": "LINK/GBP"
   },
   {
     "asset": "LINK",
     "currency": "ZUSD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.5000000000",
+    "increment": "0.0000100000",
     "label": "LINK/USD"
   },
   {
     "asset": "LINK",
     "currency": "USDT",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.5000000000",
+    "increment": "0.0000100000",
     "label": "LINK/USDT"
   },
   {
     "asset": "LINK",
     "currency": "XXBT",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.5000000000",
+    "increment": "0.0000000100",
     "label": "LINK/XBT"
   },
   {
     "asset": "LSK",
     "currency": "XETH",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "5.0000000000",
+    "increment": "0.0000000100",
     "label": "LSK/ETH"
   },
   {
     "asset": "LSK",
     "currency": "ZEUR",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "5.0000000000",
+    "increment": "0.0000010000",
     "label": "LSK/EUR"
   },
   {
     "asset": "LSK",
     "currency": "ZUSD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "5.0000000000",
+    "increment": "0.0000010000",
     "label": "LSK/USD"
   },
   {
     "asset": "LSK",
     "currency": "XXBT",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "5.0000000000",
+    "increment": "0.0000000010",
     "label": "LSK/XBT"
   },
   {
     "asset": "XLTC",
     "currency": "ZAUD",
-    "min_size": "0.1",
-    "increment": "0.00010000",
+    "min_size": "0.0500000000",
+    "increment": "0.0100000000",
     "label": "LTC/AUD"
   },
   {
     "asset": "XLTC",
     "currency": "XETH",
-    "min_size": "0.1",
-    "increment": "0.00010000",
+    "min_size": "0.0500000000",
+    "increment": "0.0000100000",
     "label": "LTC/ETH"
   },
   {
     "asset": "XLTC",
     "currency": "ZGBP",
-    "min_size": "0.1",
-    "increment": "0.00010000",
+    "min_size": "0.0500000000",
+    "increment": "0.0000100000",
     "label": "LTC/GBP"
   },
   {
     "asset": "XLTC",
     "currency": "USDT",
-    "min_size": "0.1",
-    "increment": "0.00010000",
+    "min_size": "0.0500000000",
+    "increment": "0.0000100000",
     "label": "LTC/USDT"
   },
   {
     "asset": "MANA",
     "currency": "XETH",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "50.0000000000",
+    "increment": "0.0000001000",
     "label": "MANA/ETH"
   },
   {
     "asset": "MANA",
     "currency": "ZEUR",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "50.0000000000",
+    "increment": "0.0000100000",
     "label": "MANA/EUR"
   },
   {
     "asset": "MANA",
     "currency": "ZUSD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "50.0000000000",
+    "increment": "0.0000100000",
     "label": "MANA/USD"
   },
   {
     "asset": "MANA",
     "currency": "XXBT",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "50.0000000000",
+    "increment": "0.0000000100",
     "label": "MANA/XBT"
   },
   {
     "asset": "NANO",
     "currency": "XETH",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "2.0000000000",
+    "increment": "0.0000000100",
     "label": "NANO/ETH"
   },
   {
     "asset": "NANO",
     "currency": "ZEUR",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "2.0000000000",
+    "increment": "0.0000010000",
     "label": "NANO/EUR"
   },
   {
     "asset": "NANO",
     "currency": "ZUSD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "2.0000000000",
+    "increment": "0.0000010000",
     "label": "NANO/USD"
   },
   {
     "asset": "NANO",
     "currency": "XXBT",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "2.0000000000",
+    "increment": "0.0000000010",
     "label": "NANO/XBT"
   },
   {
     "asset": "OMG",
     "currency": "XETH",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "2.0000000000",
+    "increment": "0.0000000100",
     "label": "OMG/ETH"
   },
   {
     "asset": "OMG",
     "currency": "ZEUR",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "2.0000000000",
+    "increment": "0.0000010000",
     "label": "OMG/EUR"
   },
   {
     "asset": "OMG",
     "currency": "ZUSD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "2.0000000000",
+    "increment": "0.0000010000",
     "label": "OMG/USD"
   },
   {
     "asset": "OMG",
     "currency": "XXBT",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "2.0000000000",
+    "increment": "0.0000000010",
     "label": "OMG/XBT"
   },
   {
     "asset": "OXT",
     "currency": "XETH",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "25.0000000000",
+    "increment": "0.0000001000",
     "label": "OXT/ETH"
   },
   {
     "asset": "OXT",
     "currency": "ZEUR",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "25.0000000000",
+    "increment": "0.0000100000",
     "label": "OXT/EUR"
   },
   {
     "asset": "OXT",
     "currency": "ZUSD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "25.0000000000",
+    "increment": "0.0000100000",
     "label": "OXT/USD"
   },
   {
     "asset": "OXT",
     "currency": "XXBT",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "25.0000000000",
+    "increment": "0.0000000100",
     "label": "OXT/XBT"
   },
   {
     "asset": "PAXG",
     "currency": "XETH",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.0040000000",
+    "increment": "0.0000010000",
     "label": "PAXG/ETH"
   },
   {
     "asset": "PAXG",
     "currency": "ZEUR",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.0040000000",
+    "increment": "0.0100000000",
     "label": "PAXG/EUR"
   },
   {
     "asset": "PAXG",
     "currency": "ZUSD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.0040000000",
+    "increment": "0.0100000000",
     "label": "PAXG/USD"
   },
   {
     "asset": "PAXG",
     "currency": "XXBT",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.0040000000",
+    "increment": "0.0000010000",
     "label": "PAXG/XBT"
   },
   {
     "asset": "QTUM",
     "currency": "XETH",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "2.5000000000",
+    "increment": "0.0000001000",
     "label": "QTUM/ETH"
   },
   {
     "asset": "QTUM",
     "currency": "ZEUR",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "2.5000000000",
+    "increment": "0.0000100000",
     "label": "QTUM/EUR"
   },
   {
     "asset": "QTUM",
     "currency": "ZUSD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "2.5000000000",
+    "increment": "0.0000100000",
     "label": "QTUM/USD"
   },
   {
     "asset": "QTUM",
     "currency": "XXBT",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "2.5000000000",
+    "increment": "0.0000001000",
     "label": "QTUM/XBT"
   },
   {
     "asset": "REPV2",
     "currency": "XETH",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.3000000000",
+    "increment": "0.0000100000",
     "label": "REPV2/ETH"
   },
   {
     "asset": "REPV2",
     "currency": "ZEUR",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.3000000000",
+    "increment": "0.0010000000",
     "label": "REPV2/EUR"
   },
   {
     "asset": "REPV2",
     "currency": "ZUSD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.3000000000",
+    "increment": "0.0010000000",
     "label": "REPV2/USD"
   },
   {
     "asset": "REPV2",
     "currency": "XXBT",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.3000000000",
+    "increment": "0.0000010000",
     "label": "REPV2/XBT"
   },
   {
     "asset": "SC",
     "currency": "XETH",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "1500.0000000000",
+    "increment": "0.0000000100",
     "label": "SC/ETH"
   },
   {
     "asset": "SC",
     "currency": "ZEUR",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "1500.0000000000",
+    "increment": "0.0000100000",
     "label": "SC/EUR"
   },
   {
     "asset": "SC",
     "currency": "ZUSD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "1500.0000000000",
+    "increment": "0.0000100000",
     "label": "SC/USD"
   },
   {
     "asset": "SC",
     "currency": "XXBT",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "1500.0000000000",
+    "increment": "0.0000000001",
     "label": "SC/XBT"
   },
   {
     "asset": "SNX",
     "currency": "ZAUD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.5000000000",
+    "increment": "0.0010000000",
     "label": "SNX/AUD"
   },
   {
     "asset": "SNX",
     "currency": "XETH",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.5000000000",
+    "increment": "0.0000100000",
     "label": "SNX/ETH"
   },
   {
     "asset": "SNX",
     "currency": "ZEUR",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.5000000000",
+    "increment": "0.0010000000",
     "label": "SNX/EUR"
   },
   {
     "asset": "SNX",
     "currency": "ZGBP",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.5000000000",
+    "increment": "0.0010000000",
     "label": "SNX/GBP"
   },
   {
     "asset": "SNX",
     "currency": "ZUSD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.5000000000",
+    "increment": "0.0010000000",
     "label": "SNX/USD"
   },
   {
     "asset": "SNX",
     "currency": "XXBT",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.5000000000",
+    "increment": "0.0000001000",
     "label": "SNX/XBT"
   },
   {
     "asset": "STORJ",
     "currency": "XETH",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "20.0000000000",
+    "increment": "0.0000001000",
     "label": "STORJ/ETH"
   },
   {
     "asset": "STORJ",
     "currency": "ZEUR",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "20.0000000000",
+    "increment": "0.0000100000",
     "label": "STORJ/EUR"
   },
   {
     "asset": "STORJ",
     "currency": "ZUSD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "20.0000000000",
+    "increment": "0.0000100000",
     "label": "STORJ/USD"
   },
   {
     "asset": "STORJ",
     "currency": "XXBT",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "20.0000000000",
+    "increment": "0.0000000010",
     "label": "STORJ/XBT"
   },
   {
     "asset": "TBTC",
     "currency": "XETH",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.0002000000",
+    "increment": "0.0010000000",
     "label": "TBTC/ETH"
   },
   {
     "asset": "TBTC",
     "currency": "ZEUR",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.0002000000",
+    "increment": "0.1000000000",
     "label": "TBTC/EUR"
   },
   {
     "asset": "TBTC",
     "currency": "ZUSD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.0002000000",
+    "increment": "0.1000000000",
     "label": "TBTC/USD"
   },
   {
     "asset": "TBTC",
     "currency": "XXBT",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.0002000000",
+    "increment": "0.0000100000",
     "label": "TBTC/XBT"
   },
   {
     "asset": "TRX",
     "currency": "XETH",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "250.0000000000",
+    "increment": "0.0000000100",
     "label": "TRX/ETH"
   },
   {
     "asset": "TRX",
     "currency": "ZEUR",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "250.0000000000",
+    "increment": "0.0000010000",
     "label": "TRX/EUR"
   },
   {
     "asset": "TRX",
     "currency": "ZUSD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "250.0000000000",
+    "increment": "0.0000010000",
     "label": "TRX/USD"
   },
   {
     "asset": "TRX",
     "currency": "XXBT",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "250.0000000000",
+    "increment": "0.0000000001",
     "label": "TRX/XBT"
   },
   {
     "asset": "UNI",
     "currency": "XETH",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "1.0000000000",
+    "increment": "0.0000100000",
     "label": "UNI/ETH"
   },
   {
     "asset": "UNI",
     "currency": "ZEUR",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "1.0000000000",
+    "increment": "0.0010000000",
     "label": "UNI/EUR"
   },
   {
     "asset": "UNI",
     "currency": "ZUSD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "1.0000000000",
+    "increment": "0.0010000000",
     "label": "UNI/USD"
   },
   {
     "asset": "UNI",
     "currency": "XXBT",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "1.0000000000",
+    "increment": "0.0000001000",
     "label": "UNI/XBT"
   },
   {
     "asset": "USDC",
     "currency": "ZAUD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "5.0000000000",
+    "increment": "0.0001000000",
     "label": "USDC/AUD"
   },
   {
     "asset": "USDC",
     "currency": "ZEUR",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "5.0000000000",
+    "increment": "0.0001000000",
     "label": "USDC/EUR"
   },
   {
     "asset": "USDC",
     "currency": "ZGBP",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "5.0000000000",
+    "increment": "0.0001000000",
     "label": "USDC/GBP"
   },
   {
     "asset": "ZUSD",
     "currency": "CHF",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "10.0000000000",
+    "increment": "0.0000100000",
     "label": "USD/CHF"
   },
   {
     "asset": "USDC",
     "currency": "ZUSD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "5.0000000000",
+    "increment": "0.0001000000",
     "label": "USDC/USD"
   },
   {
     "asset": "USDC",
     "currency": "USDT",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "5.0000000000",
+    "increment": "0.0001000000",
     "label": "USDC/USDT"
   },
   {
     "asset": "USDT",
     "currency": "ZAUD",
-    "min_size": "5",
-    "increment": "0.00010000",
+    "min_size": "5.0000000000",
+    "increment": "0.0001000000",
     "label": "USDT/AUD"
   },
   {
     "asset": "USDT",
     "currency": "ZCAD",
-    "min_size": "5",
-    "increment": "0.00010000",
+    "min_size": "5.0000000000",
+    "increment": "0.0001000000",
     "label": "USDT/CAD"
   },
   {
     "asset": "USDT",
     "currency": "CHF",
-    "min_size": "5",
-    "increment": "0.00010000",
+    "min_size": "5.0000000000",
+    "increment": "0.0000100000",
     "label": "USDT/CHF"
   },
   {
     "asset": "USDT",
     "currency": "ZEUR",
-    "min_size": "5",
-    "increment": "0.00010000",
+    "min_size": "5.0000000000",
+    "increment": "0.0001000000",
     "label": "USDT/EUR"
   },
   {
     "asset": "USDT",
     "currency": "ZGBP",
-    "min_size": "5",
-    "increment": "0.00010000",
+    "min_size": "5.0000000000",
+    "increment": "0.0001000000",
     "label": "USDT/GBP"
   },
   {
     "asset": "USDT",
     "currency": "ZJPY",
-    "min_size": "5",
-    "increment": "0.00010000",
+    "min_size": "5.0000000000",
+    "increment": "0.0010000000",
     "label": "USDT/JPY"
   },
   {
     "asset": "USDT",
     "currency": "ZUSD",
-    "min_size": "5",
-    "increment": "0.00010000",
+    "min_size": "5.0000000000",
+    "increment": "0.0001000000",
     "label": "USDT/USD"
   },
   {
     "asset": "WAVES",
     "currency": "XETH",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "2.0000000000",
+    "increment": "0.0000001000",
     "label": "WAVES/ETH"
   },
   {
     "asset": "WAVES",
     "currency": "ZEUR",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "2.0000000000",
+    "increment": "0.0001000000",
     "label": "WAVES/EUR"
   },
   {
     "asset": "WAVES",
     "currency": "ZUSD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "2.0000000000",
+    "increment": "0.0001000000",
     "label": "WAVES/USD"
   },
   {
     "asset": "WAVES",
     "currency": "XXBT",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "2.0000000000",
+    "increment": "0.0000000100",
     "label": "WAVES/XBT"
   },
   {
     "asset": "XXBT",
     "currency": "ZAUD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.0002000000",
+    "increment": "0.1000000000",
     "label": "XBT/AUD"
   },
   {
     "asset": "XXBT",
     "currency": "CHF",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.0002000000",
+    "increment": "0.1000000000",
     "label": "XBT/CHF"
   },
   {
     "asset": "XXBT",
     "currency": "DAI",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.0002000000",
+    "increment": "0.1000000000",
     "label": "XBT/DAI"
   },
   {
     "asset": "XXBT",
     "currency": "USDC",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.0002000000",
+    "increment": "0.0100000000",
     "label": "XBT/USDC"
   },
   {
     "asset": "XXBT",
     "currency": "USDT",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.0002000000",
+    "increment": "0.1000000000",
     "label": "XBT/USDT"
   },
   {
     "asset": "XXDG",
     "currency": "ZEUR",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "50.0000000000",
+    "increment": "0.0000001000",
     "label": "XDG/EUR"
   },
   {
     "asset": "XXDG",
     "currency": "ZUSD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "50.0000000000",
+    "increment": "0.0000001000",
     "label": "XDG/USD"
   },
   {
     "asset": "XETC",
     "currency": "XETH",
-    "min_size": "0.3",
-    "increment": "0.00010000",
+    "min_size": "1.0000000000",
+    "increment": "0.0000010000",
     "label": "ETC/ETH"
   },
   {
     "asset": "XETC",
     "currency": "XXBT",
-    "min_size": "0.3",
-    "increment": "0.00010000",
+    "min_size": "1.0000000000",
+    "increment": "0.0000010000",
     "label": "ETC/XBT"
   },
   {
     "asset": "XETC",
     "currency": "ZEUR",
-    "min_size": "0.3",
-    "increment": "0.00010000",
+    "min_size": "1.0000000000",
+    "increment": "0.0010000000",
     "label": "ETC/EUR"
   },
   {
     "asset": "XETC",
     "currency": "ZUSD",
-    "min_size": "0.3",
-    "increment": "0.00010000",
+    "min_size": "1.0000000000",
+    "increment": "0.0010000000",
     "label": "ETC/USD"
   },
   {
     "asset": "XETH",
     "currency": "XXBT",
-    "min_size": "0.02",
-    "increment": "0.00010000",
+    "min_size": "0.0050000000",
+    "increment": "0.0000100000",
     "label": "ETH/XBT"
   },
   {
     "asset": "XETH",
     "currency": "ZCAD",
-    "min_size": "0.02",
-    "increment": "0.00010000",
+    "min_size": "0.0050000000",
+    "increment": "0.0100000000",
     "label": "ETH/CAD"
   },
   {
     "asset": "XETH",
     "currency": "ZEUR",
-    "min_size": "0.02",
-    "increment": "0.00010000",
+    "min_size": "0.0050000000",
+    "increment": "0.0100000000",
     "label": "ETH/EUR"
   },
   {
     "asset": "XETH",
     "currency": "ZGBP",
-    "min_size": "0.02",
-    "increment": "0.00010000",
+    "min_size": "0.0050000000",
+    "increment": "0.0100000000",
     "label": "ETH/GBP"
   },
   {
     "asset": "XETH",
     "currency": "ZJPY",
-    "min_size": "0.02",
-    "increment": "0.00010000",
+    "min_size": "0.0050000000",
+    "increment": "1.0000000000",
     "label": "ETH/JPY"
   },
   {
     "asset": "XETH",
     "currency": "ZUSD",
-    "min_size": "0.02",
-    "increment": "0.00010000",
+    "min_size": "0.0050000000",
+    "increment": "0.0100000000",
     "label": "ETH/USD"
   },
   {
     "asset": "XLTC",
     "currency": "XXBT",
-    "min_size": "0.1",
-    "increment": "0.00010000",
+    "min_size": "0.0500000000",
+    "increment": "0.0000010000",
     "label": "LTC/XBT"
   },
   {
     "asset": "XLTC",
     "currency": "ZEUR",
-    "min_size": "0.1",
-    "increment": "0.00010000",
+    "min_size": "0.0500000000",
+    "increment": "0.0100000000",
     "label": "LTC/EUR"
   },
   {
     "asset": "XLTC",
     "currency": "ZJPY",
-    "min_size": "0.1",
-    "increment": "0.00010000",
+    "min_size": "0.0500000000",
+    "increment": "1.0000000000",
     "label": "LTC/JPY"
   },
   {
     "asset": "XLTC",
     "currency": "ZUSD",
-    "min_size": "0.1",
-    "increment": "0.00010000",
+    "min_size": "0.0500000000",
+    "increment": "0.0100000000",
     "label": "LTC/USD"
   },
   {
     "asset": "XMLN",
     "currency": "XETH",
-    "min_size": "0.1",
-    "increment": "0.00010000",
+    "min_size": "0.2000000000",
+    "increment": "0.0000100000",
     "label": "MLN/ETH"
   },
   {
     "asset": "XMLN",
     "currency": "XXBT",
-    "min_size": "0.1",
-    "increment": "0.00010000",
+    "min_size": "0.2000000000",
+    "increment": "0.0000010000",
     "label": "MLN/XBT"
   },
   {
     "asset": "XMLN",
     "currency": "ZEUR",
-    "min_size": "0.1",
-    "increment": "0.00010000",
+    "min_size": "0.2000000000",
+    "increment": "0.0010000000",
     "label": "MLN/EUR"
   },
   {
     "asset": "XMLN",
     "currency": "ZUSD",
-    "min_size": "0.1",
-    "increment": "0.00010000",
+    "min_size": "0.2000000000",
+    "increment": "0.0010000000",
     "label": "MLN/USD"
   },
   {
     "asset": "XREP",
     "currency": "XETH",
-    "min_size": "0.3",
-    "increment": "0.00010000",
+    "min_size": "0.3000000000",
+    "increment": "0.0000100000",
     "label": "REP/ETH"
   },
   {
     "asset": "XREP",
     "currency": "XXBT",
-    "min_size": "0.3",
-    "increment": "0.00010000",
+    "min_size": "0.3000000000",
+    "increment": "0.0000010000",
     "label": "REP/XBT"
   },
   {
     "asset": "XREP",
     "currency": "ZEUR",
-    "min_size": "0.3",
-    "increment": "0.00010000",
+    "min_size": "0.3000000000",
+    "increment": "0.0010000000",
     "label": "REP/EUR"
   },
   {
     "asset": "XREP",
     "currency": "ZUSD",
-    "min_size": "0.3",
-    "increment": "0.00010000",
+    "min_size": "0.3000000000",
+    "increment": "0.0010000000",
     "label": "REP/USD"
   },
   {
     "asset": "XXRP",
     "currency": "ZAUD",
-    "min_size": "30",
-    "increment": "0.00010000",
+    "min_size": "20.0000000000",
+    "increment": "0.0000100000",
     "label": "XRP/AUD"
   },
   {
     "asset": "XXRP",
     "currency": "XETH",
-    "min_size": "30",
-    "increment": "0.00010000",
+    "min_size": "20.0000000000",
+    "increment": "0.0000001000",
     "label": "XRP/ETH"
   },
   {
     "asset": "XXRP",
     "currency": "ZGBP",
-    "min_size": "30",
-    "increment": "0.00010000",
+    "min_size": "20.0000000000",
+    "increment": "0.0000100000",
     "label": "XRP/GBP"
   },
   {
     "asset": "XXRP",
     "currency": "USDT",
-    "min_size": "30",
-    "increment": "0.00010000",
+    "min_size": "20.0000000000",
+    "increment": "0.0000100000",
     "label": "XRP/USDT"
   },
   {
     "asset": "XTZ",
     "currency": "ZAUD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "3.0000000000",
+    "increment": "0.0001000000",
     "label": "XTZ/AUD"
   },
   {
     "asset": "XTZ",
     "currency": "XETH",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "3.0000000000",
+    "increment": "0.0000001000",
     "label": "XTZ/ETH"
   },
   {
     "asset": "XTZ",
     "currency": "ZEUR",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "3.0000000000",
+    "increment": "0.0001000000",
     "label": "XTZ/EUR"
   },
   {
     "asset": "XTZ",
     "currency": "ZGBP",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "3.0000000000",
+    "increment": "0.0001000000",
     "label": "XTZ/GBP"
   },
   {
     "asset": "XTZ",
     "currency": "ZUSD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "3.0000000000",
+    "increment": "0.0001000000",
     "label": "XTZ/USD"
   },
   {
     "asset": "XTZ",
     "currency": "XXBT",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "3.0000000000",
+    "increment": "0.0000001000",
     "label": "XTZ/XBT"
   },
   {
     "asset": "XXBT",
     "currency": "ZCAD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.0002000000",
+    "increment": "0.1000000000",
     "label": "XBT/CAD"
   },
   {
     "asset": "XXBT",
     "currency": "ZEUR",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.0002000000",
+    "increment": "0.1000000000",
     "label": "XBT/EUR"
   },
   {
     "asset": "XXBT",
     "currency": "ZGBP",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.0002000000",
+    "increment": "0.1000000000",
     "label": "XBT/GBP"
   },
   {
     "asset": "XXBT",
     "currency": "ZJPY",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.0002000000",
+    "increment": "1.0000000000",
     "label": "XBT/JPY"
   },
   {
     "asset": "XXBT",
     "currency": "ZUSD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.0002000000",
+    "increment": "0.1000000000",
     "label": "XBT/USD"
   },
   {
     "asset": "XXDG",
     "currency": "XXBT",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "50.0000000000",
+    "increment": "0.0000000100",
     "label": "XDG/XBT"
   },
   {
     "asset": "XXLM",
     "currency": "XXBT",
-    "min_size": "300",
-    "increment": "0.00010000",
+    "min_size": "20.0000000000",
+    "increment": "0.0000000100",
     "label": "XLM/XBT"
   },
   {
     "asset": "XXLM",
     "currency": "ZAUD",
-    "min_size": "300",
-    "increment": "0.00010000",
+    "min_size": "20.0000000000",
+    "increment": "0.0000100000",
     "label": "XLM/AUD"
   },
   {
     "asset": "XXLM",
     "currency": "ZEUR",
-    "min_size": "300",
-    "increment": "0.00010000",
+    "min_size": "20.0000000000",
+    "increment": "0.0000010000",
     "label": "XLM/EUR"
   },
   {
     "asset": "XXLM",
     "currency": "ZGBP",
-    "min_size": "300",
-    "increment": "0.00010000",
+    "min_size": "20.0000000000",
+    "increment": "0.0000100000",
     "label": "XLM/GBP"
   },
   {
     "asset": "XXLM",
     "currency": "ZUSD",
-    "min_size": "300",
-    "increment": "0.00010000",
+    "min_size": "20.0000000000",
+    "increment": "0.0000010000",
     "label": "XLM/USD"
   },
   {
     "asset": "XXMR",
     "currency": "XXBT",
-    "min_size": "0.1",
-    "increment": "0.00010000",
+    "min_size": "0.0500000000",
+    "increment": "0.0000010000",
     "label": "XMR/XBT"
   },
   {
     "asset": "XXMR",
     "currency": "ZEUR",
-    "min_size": "0.1",
-    "increment": "0.00010000",
+    "min_size": "0.0500000000",
+    "increment": "0.0100000000",
     "label": "XMR/EUR"
   },
   {
     "asset": "XXMR",
     "currency": "ZUSD",
-    "min_size": "0.1",
-    "increment": "0.00010000",
+    "min_size": "0.0500000000",
+    "increment": "0.0100000000",
     "label": "XMR/USD"
   },
   {
     "asset": "XXRP",
     "currency": "XXBT",
-    "min_size": "30",
-    "increment": "0.00010000",
+    "min_size": "20.0000000000",
+    "increment": "0.0000000100",
     "label": "XRP/XBT"
   },
   {
     "asset": "XXRP",
     "currency": "ZCAD",
-    "min_size": "30",
-    "increment": "0.00010000",
+    "min_size": "20.0000000000",
+    "increment": "0.0000100000",
     "label": "XRP/CAD"
   },
   {
     "asset": "XXRP",
     "currency": "ZEUR",
-    "min_size": "30",
-    "increment": "0.00010000",
+    "min_size": "20.0000000000",
+    "increment": "0.0000100000",
     "label": "XRP/EUR"
   },
   {
     "asset": "XXRP",
     "currency": "ZJPY",
-    "min_size": "30",
-    "increment": "0.00010000",
+    "min_size": "20.0000000000",
+    "increment": "0.0010000000",
     "label": "XRP/JPY"
   },
   {
     "asset": "XXRP",
     "currency": "ZUSD",
-    "min_size": "30",
-    "increment": "0.00010000",
+    "min_size": "20.0000000000",
+    "increment": "0.0000100000",
     "label": "XRP/USD"
   },
   {
     "asset": "XZEC",
     "currency": "XXBT",
-    "min_size": "0.03",
-    "increment": "0.00010000",
+    "min_size": "0.1000000000",
+    "increment": "0.0000100000",
     "label": "ZEC/XBT"
   },
   {
     "asset": "XZEC",
     "currency": "ZEUR",
-    "min_size": "0.03",
-    "increment": "0.00010000",
+    "min_size": "0.1000000000",
+    "increment": "0.0010000000",
     "label": "ZEC/EUR"
   },
   {
     "asset": "XZEC",
     "currency": "ZUSD",
-    "min_size": "0.03",
-    "increment": "0.00010000",
+    "min_size": "0.1000000000",
+    "increment": "0.0100000000",
     "label": "ZEC/USD"
   },
   {
     "asset": "YFI",
     "currency": "ZAUD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.0002000000",
+    "increment": "1.0000000000",
     "label": "YFI/AUD"
   },
   {
     "asset": "YFI",
     "currency": "XETH",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.0002000000",
+    "increment": "0.0100000000",
     "label": "YFI/ETH"
   },
   {
     "asset": "YFI",
     "currency": "ZEUR",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.0002000000",
+    "increment": "1.0000000000",
     "label": "YFI/EUR"
   },
   {
     "asset": "YFI",
     "currency": "ZGBP",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.0002000000",
+    "increment": "1.0000000000",
     "label": "YFI/GBP"
   },
   {
     "asset": "YFI",
     "currency": "ZUSD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.0002000000",
+    "increment": "1.0000000000",
     "label": "YFI/USD"
   },
   {
     "asset": "YFI",
     "currency": "XXBT",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "0.0002000000",
+    "increment": "0.0001000000",
     "label": "YFI/XBT"
   },
   {
     "asset": "ZEUR",
     "currency": "ZUSD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "5.0000000000",
+    "increment": "0.0000100000",
     "label": "EUR/USD"
   },
   {
     "asset": "ZGBP",
     "currency": "ZUSD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "5.0000000000",
+    "increment": "0.0000100000",
     "label": "GBP/USD"
   },
   {
     "asset": "ZUSD",
     "currency": "ZCAD",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "10.0000000000",
+    "increment": "0.0000100000",
     "label": "USD/CAD"
   },
   {
     "asset": "ZUSD",
     "currency": "ZJPY",
-    "min_size": "0.01",
-    "increment": "0.00010000",
+    "min_size": "10.0000000000",
+    "increment": "0.0010000000",
     "label": "USD/JPY"
   }
 ]

--- a/extensions/exchanges/kraken/products.json
+++ b/extensions/exchanges/kraken/products.json
@@ -3,1981 +3,1981 @@
     "asset": "AAVE",
     "currency": "ZAUD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "AAVE/AUD"
   },
   {
     "asset": "AAVE",
     "currency": "XETH",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "AAVE/ETH"
   },
   {
     "asset": "AAVE",
     "currency": "ZEUR",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "AAVE/EUR"
   },
   {
     "asset": "AAVE",
     "currency": "ZGBP",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "AAVE/GBP"
   },
   {
     "asset": "AAVE",
     "currency": "ZUSD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "AAVE/USD"
   },
   {
     "asset": "AAVE",
     "currency": "XXBT",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "AAVE/XBT"
   },
   {
     "asset": "ADA",
     "currency": "ZAUD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ADA/AUD"
   },
   {
     "asset": "ADA",
     "currency": "XETH",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ADA/ETH"
   },
   {
     "asset": "ADA",
     "currency": "ZEUR",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ADA/EUR"
   },
   {
     "asset": "ADA",
     "currency": "ZGBP",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ADA/GBP"
   },
   {
     "asset": "ADA",
     "currency": "ZUSD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ADA/USD"
   },
   {
     "asset": "ADA",
     "currency": "USDT",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ADA/USDT"
   },
   {
     "asset": "ADA",
     "currency": "XXBT",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ADA/XBT"
   },
   {
     "asset": "ALGO",
     "currency": "XETH",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ALGO/ETH"
   },
   {
     "asset": "ALGO",
     "currency": "ZEUR",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ALGO/EUR"
   },
   {
     "asset": "ALGO",
     "currency": "ZGBP",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ALGO/GBP"
   },
   {
     "asset": "ALGO",
     "currency": "ZUSD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ALGO/USD"
   },
   {
     "asset": "ALGO",
     "currency": "XXBT",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ALGO/XBT"
   },
   {
     "asset": "ANT",
     "currency": "XETH",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ANT/ETH"
   },
   {
     "asset": "ANT",
     "currency": "ZEUR",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ANT/EUR"
   },
   {
     "asset": "ANT",
     "currency": "ZUSD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ANT/USD"
   },
   {
     "asset": "ANT",
     "currency": "XXBT",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ANT/XBT"
   },
   {
     "asset": "ATOM",
     "currency": "ZAUD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ATOM/AUD"
   },
   {
     "asset": "ATOM",
     "currency": "XETH",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ATOM/ETH"
   },
   {
     "asset": "ATOM",
     "currency": "ZEUR",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ATOM/EUR"
   },
   {
     "asset": "ATOM",
     "currency": "ZGBP",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ATOM/GBP"
   },
   {
     "asset": "ATOM",
     "currency": "ZUSD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ATOM/USD"
   },
   {
     "asset": "ATOM",
     "currency": "XXBT",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ATOM/XBT"
   },
   {
     "asset": "ZAUD",
     "currency": "ZJPY",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "AUD/JPY"
   },
   {
     "asset": "ZAUD",
     "currency": "ZUSD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "AUD/USD"
   },
   {
     "asset": "BAL",
     "currency": "XETH",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "BAL/ETH"
   },
   {
     "asset": "BAL",
     "currency": "ZEUR",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "BAL/EUR"
   },
   {
     "asset": "BAL",
     "currency": "ZUSD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "BAL/USD"
   },
   {
     "asset": "BAL",
     "currency": "XXBT",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "BAL/XBT"
   },
   {
     "asset": "BAT",
     "currency": "XETH",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "BAT/ETH"
   },
   {
     "asset": "BAT",
     "currency": "ZEUR",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "BAT/EUR"
   },
   {
     "asset": "BAT",
     "currency": "ZUSD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "BAT/USD"
   },
   {
     "asset": "BAT",
     "currency": "XXBT",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "BAT/XBT"
   },
   {
     "asset": "BCH",
     "currency": "ZAUD",
     "min_size": "0.002",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "BCH/AUD"
   },
   {
     "asset": "BCH",
     "currency": "XETH",
     "min_size": "0.002",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "BCH/ETH"
   },
   {
     "asset": "BCH",
     "currency": "ZEUR",
     "min_size": "0.002",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "BCH/EUR"
   },
   {
     "asset": "BCH",
     "currency": "ZGBP",
     "min_size": "0.002",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "BCH/GBP"
   },
   {
     "asset": "BCH",
     "currency": "ZJPY",
     "min_size": "0.002",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "BCH/JPY"
   },
   {
     "asset": "BCH",
     "currency": "ZUSD",
     "min_size": "0.002",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "BCH/USD"
   },
   {
     "asset": "BCH",
     "currency": "USDT",
     "min_size": "0.002",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "BCH/USDT"
   },
   {
     "asset": "BCH",
     "currency": "XXBT",
     "min_size": "0.002",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "BCH/XBT"
   },
   {
     "asset": "COMP",
     "currency": "XETH",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "COMP/ETH"
   },
   {
     "asset": "COMP",
     "currency": "ZEUR",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "COMP/EUR"
   },
   {
     "asset": "COMP",
     "currency": "ZUSD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "COMP/USD"
   },
   {
     "asset": "COMP",
     "currency": "XXBT",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "COMP/XBT"
   },
   {
     "asset": "CRV",
     "currency": "XETH",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "CRV/ETH"
   },
   {
     "asset": "CRV",
     "currency": "ZEUR",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "CRV/EUR"
   },
   {
     "asset": "CRV",
     "currency": "ZUSD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "CRV/USD"
   },
   {
     "asset": "CRV",
     "currency": "XXBT",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "CRV/XBT"
   },
   {
     "asset": "DAI",
     "currency": "ZEUR",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "DAI/EUR"
   },
   {
     "asset": "DAI",
     "currency": "ZUSD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "DAI/USD"
   },
   {
     "asset": "DAI",
     "currency": "USDT",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "DAI/USDT"
   },
   {
     "asset": "DASH",
     "currency": "ZEUR",
     "min_size": "0.03",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "DASH/EUR"
   },
   {
     "asset": "DASH",
     "currency": "ZUSD",
     "min_size": "0.03",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "DASH/USD"
   },
   {
     "asset": "DASH",
     "currency": "XXBT",
     "min_size": "0.03",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "DASH/XBT"
   },
   {
     "asset": "DOT",
     "currency": "ZAUD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "DOT/AUD"
   },
   {
     "asset": "DOT",
     "currency": "XETH",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "DOT/ETH"
   },
   {
     "asset": "DOT",
     "currency": "ZEUR",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "DOT/EUR"
   },
   {
     "asset": "DOT",
     "currency": "ZGBP",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "DOT/GBP"
   },
   {
     "asset": "DOT",
     "currency": "ZUSD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "DOT/USD"
   },
   {
     "asset": "DOT",
     "currency": "USDT",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "DOT/USDT"
   },
   {
     "asset": "DOT",
     "currency": "XXBT",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "DOT/XBT"
   },
   {
     "asset": "EOS",
     "currency": "XETH",
     "min_size": "3.0",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "EOS/ETH"
   },
   {
     "asset": "EOS",
     "currency": "ZEUR",
     "min_size": "3.0",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "EOS/EUR"
   },
   {
     "asset": "EOS",
     "currency": "ZUSD",
     "min_size": "3.0",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "EOS/USD"
   },
   {
     "asset": "EOS",
     "currency": "USDT",
     "min_size": "3.0",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "EOS/USDT"
   },
   {
     "asset": "EOS",
     "currency": "XXBT",
     "min_size": "3.0",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "EOS/XBT"
   },
   {
     "asset": "ETH2.S",
     "currency": "XETH",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ETH2.S/ETH"
   },
   {
     "asset": "XETH",
     "currency": "ZAUD",
     "min_size": "0.02",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ETH/AUD"
   },
   {
     "asset": "XETH",
     "currency": "CHF",
     "min_size": "0.02",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ETH/CHF"
   },
   {
     "asset": "XETH",
     "currency": "DAI",
     "min_size": "0.02",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ETH/DAI"
   },
   {
     "asset": "XETH",
     "currency": "USDC",
     "min_size": "0.02",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ETH/USDC"
   },
   {
     "asset": "XETH",
     "currency": "USDT",
     "min_size": "0.02",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ETH/USDT"
   },
   {
     "asset": "ZEUR",
     "currency": "ZAUD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "EUR/AUD"
   },
   {
     "asset": "ZEUR",
     "currency": "ZCAD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "EUR/CAD"
   },
   {
     "asset": "ZEUR",
     "currency": "CHF",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "EUR/CHF"
   },
   {
     "asset": "ZEUR",
     "currency": "ZGBP",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "EUR/GBP"
   },
   {
     "asset": "ZEUR",
     "currency": "ZJPY",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "EUR/JPY"
   },
   {
     "asset": "FIL",
     "currency": "ZAUD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "FIL/AUD"
   },
   {
     "asset": "FIL",
     "currency": "XETH",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "FIL/ETH"
   },
   {
     "asset": "FIL",
     "currency": "ZEUR",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "FIL/EUR"
   },
   {
     "asset": "FIL",
     "currency": "ZGBP",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "FIL/GBP"
   },
   {
     "asset": "FIL",
     "currency": "ZUSD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "FIL/USD"
   },
   {
     "asset": "FIL",
     "currency": "XXBT",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "FIL/XBT"
   },
   {
     "asset": "FLOW",
     "currency": "XETH",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "FLOW/ETH"
   },
   {
     "asset": "FLOW",
     "currency": "ZEUR",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "FLOW/EUR"
   },
   {
     "asset": "FLOW",
     "currency": "ZGBP",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "FLOW/GBP"
   },
   {
     "asset": "FLOW",
     "currency": "ZUSD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "FLOW/USD"
   },
   {
     "asset": "FLOW",
     "currency": "XXBT",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "FLOW/XBT"
   },
   {
     "asset": "GNO",
     "currency": "XETH",
     "min_size": "0.03",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "GNO/ETH"
   },
   {
     "asset": "GNO",
     "currency": "ZEUR",
     "min_size": "0.03",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "GNO/EUR"
   },
   {
     "asset": "GNO",
     "currency": "ZUSD",
     "min_size": "0.03",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "GNO/USD"
   },
   {
     "asset": "GNO",
     "currency": "XXBT",
     "min_size": "0.03",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "GNO/XBT"
   },
   {
     "asset": "GRT",
     "currency": "ZAUD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "GRT/AUD"
   },
   {
     "asset": "GRT",
     "currency": "XETH",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "GRT/ETH"
   },
   {
     "asset": "GRT",
     "currency": "ZEUR",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "GRT/EUR"
   },
   {
     "asset": "GRT",
     "currency": "ZGBP",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "GRT/GBP"
   },
   {
     "asset": "GRT",
     "currency": "ZUSD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "GRT/USD"
   },
   {
     "asset": "GRT",
     "currency": "XXBT",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "GRT/XBT"
   },
   {
     "asset": "ICX",
     "currency": "XETH",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ICX/ETH"
   },
   {
     "asset": "ICX",
     "currency": "ZEUR",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ICX/EUR"
   },
   {
     "asset": "ICX",
     "currency": "ZUSD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ICX/USD"
   },
   {
     "asset": "ICX",
     "currency": "XXBT",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ICX/XBT"
   },
   {
     "asset": "KAVA",
     "currency": "XETH",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "KAVA/ETH"
   },
   {
     "asset": "KAVA",
     "currency": "ZEUR",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "KAVA/EUR"
   },
   {
     "asset": "KAVA",
     "currency": "ZUSD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "KAVA/USD"
   },
   {
     "asset": "KAVA",
     "currency": "XXBT",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "KAVA/XBT"
   },
   {
     "asset": "KEEP",
     "currency": "XETH",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "KEEP/ETH"
   },
   {
     "asset": "KEEP",
     "currency": "ZEUR",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "KEEP/EUR"
   },
   {
     "asset": "KEEP",
     "currency": "ZUSD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "KEEP/USD"
   },
   {
     "asset": "KEEP",
     "currency": "XXBT",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "KEEP/XBT"
   },
   {
     "asset": "KNC",
     "currency": "XETH",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "KNC/ETH"
   },
   {
     "asset": "KNC",
     "currency": "ZEUR",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "KNC/EUR"
   },
   {
     "asset": "KNC",
     "currency": "ZUSD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "KNC/USD"
   },
   {
     "asset": "KNC",
     "currency": "XXBT",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "KNC/XBT"
   },
   {
     "asset": "KSM",
     "currency": "ZAUD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "KSM/AUD"
   },
   {
     "asset": "KSM",
     "currency": "XETH",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "KSM/ETH"
   },
   {
     "asset": "KSM",
     "currency": "ZEUR",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "KSM/EUR"
   },
   {
     "asset": "KSM",
     "currency": "ZGBP",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "KSM/GBP"
   },
   {
     "asset": "KSM",
     "currency": "ZUSD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "KSM/USD"
   },
   {
     "asset": "KSM",
     "currency": "XXBT",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "KSM/XBT"
   },
   {
     "asset": "LINK",
     "currency": "ZAUD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "LINK/AUD"
   },
   {
     "asset": "LINK",
     "currency": "XETH",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "LINK/ETH"
   },
   {
     "asset": "LINK",
     "currency": "ZEUR",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "LINK/EUR"
   },
   {
     "asset": "LINK",
     "currency": "ZGBP",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "LINK/GBP"
   },
   {
     "asset": "LINK",
     "currency": "ZUSD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "LINK/USD"
   },
   {
     "asset": "LINK",
     "currency": "USDT",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "LINK/USDT"
   },
   {
     "asset": "LINK",
     "currency": "XXBT",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "LINK/XBT"
   },
   {
     "asset": "LSK",
     "currency": "XETH",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "LSK/ETH"
   },
   {
     "asset": "LSK",
     "currency": "ZEUR",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "LSK/EUR"
   },
   {
     "asset": "LSK",
     "currency": "ZUSD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "LSK/USD"
   },
   {
     "asset": "LSK",
     "currency": "XXBT",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "LSK/XBT"
   },
   {
     "asset": "XLTC",
     "currency": "ZAUD",
     "min_size": "0.1",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "LTC/AUD"
   },
   {
     "asset": "XLTC",
     "currency": "XETH",
     "min_size": "0.1",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "LTC/ETH"
   },
   {
     "asset": "XLTC",
     "currency": "ZGBP",
     "min_size": "0.1",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "LTC/GBP"
   },
   {
     "asset": "XLTC",
     "currency": "USDT",
     "min_size": "0.1",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "LTC/USDT"
   },
   {
     "asset": "MANA",
     "currency": "XETH",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "MANA/ETH"
   },
   {
     "asset": "MANA",
     "currency": "ZEUR",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "MANA/EUR"
   },
   {
     "asset": "MANA",
     "currency": "ZUSD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "MANA/USD"
   },
   {
     "asset": "MANA",
     "currency": "XXBT",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "MANA/XBT"
   },
   {
     "asset": "NANO",
     "currency": "XETH",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "NANO/ETH"
   },
   {
     "asset": "NANO",
     "currency": "ZEUR",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "NANO/EUR"
   },
   {
     "asset": "NANO",
     "currency": "ZUSD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "NANO/USD"
   },
   {
     "asset": "NANO",
     "currency": "XXBT",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "NANO/XBT"
   },
   {
     "asset": "OMG",
     "currency": "XETH",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "OMG/ETH"
   },
   {
     "asset": "OMG",
     "currency": "ZEUR",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "OMG/EUR"
   },
   {
     "asset": "OMG",
     "currency": "ZUSD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "OMG/USD"
   },
   {
     "asset": "OMG",
     "currency": "XXBT",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "OMG/XBT"
   },
   {
     "asset": "OXT",
     "currency": "XETH",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "OXT/ETH"
   },
   {
     "asset": "OXT",
     "currency": "ZEUR",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "OXT/EUR"
   },
   {
     "asset": "OXT",
     "currency": "ZUSD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "OXT/USD"
   },
   {
     "asset": "OXT",
     "currency": "XXBT",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "OXT/XBT"
   },
   {
     "asset": "PAXG",
     "currency": "XETH",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "PAXG/ETH"
   },
   {
     "asset": "PAXG",
     "currency": "ZEUR",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "PAXG/EUR"
   },
   {
     "asset": "PAXG",
     "currency": "ZUSD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "PAXG/USD"
   },
   {
     "asset": "PAXG",
     "currency": "XXBT",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "PAXG/XBT"
   },
   {
     "asset": "QTUM",
     "currency": "XETH",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "QTUM/ETH"
   },
   {
     "asset": "QTUM",
     "currency": "ZEUR",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "QTUM/EUR"
   },
   {
     "asset": "QTUM",
     "currency": "ZUSD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "QTUM/USD"
   },
   {
     "asset": "QTUM",
     "currency": "XXBT",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "QTUM/XBT"
   },
   {
     "asset": "REPV2",
     "currency": "XETH",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "REPV2/ETH"
   },
   {
     "asset": "REPV2",
     "currency": "ZEUR",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "REPV2/EUR"
   },
   {
     "asset": "REPV2",
     "currency": "ZUSD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "REPV2/USD"
   },
   {
     "asset": "REPV2",
     "currency": "XXBT",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "REPV2/XBT"
   },
   {
     "asset": "SC",
     "currency": "XETH",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "SC/ETH"
   },
   {
     "asset": "SC",
     "currency": "ZEUR",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "SC/EUR"
   },
   {
     "asset": "SC",
     "currency": "ZUSD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "SC/USD"
   },
   {
     "asset": "SC",
     "currency": "XXBT",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "SC/XBT"
   },
   {
     "asset": "SNX",
     "currency": "ZAUD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "SNX/AUD"
   },
   {
     "asset": "SNX",
     "currency": "XETH",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "SNX/ETH"
   },
   {
     "asset": "SNX",
     "currency": "ZEUR",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "SNX/EUR"
   },
   {
     "asset": "SNX",
     "currency": "ZGBP",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "SNX/GBP"
   },
   {
     "asset": "SNX",
     "currency": "ZUSD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "SNX/USD"
   },
   {
     "asset": "SNX",
     "currency": "XXBT",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "SNX/XBT"
   },
   {
     "asset": "STORJ",
     "currency": "XETH",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "STORJ/ETH"
   },
   {
     "asset": "STORJ",
     "currency": "ZEUR",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "STORJ/EUR"
   },
   {
     "asset": "STORJ",
     "currency": "ZUSD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "STORJ/USD"
   },
   {
     "asset": "STORJ",
     "currency": "XXBT",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "STORJ/XBT"
   },
   {
     "asset": "TBTC",
     "currency": "XETH",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "TBTC/ETH"
   },
   {
     "asset": "TBTC",
     "currency": "ZEUR",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "TBTC/EUR"
   },
   {
     "asset": "TBTC",
     "currency": "ZUSD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "TBTC/USD"
   },
   {
     "asset": "TBTC",
     "currency": "XXBT",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "TBTC/XBT"
   },
   {
     "asset": "TRX",
     "currency": "XETH",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "TRX/ETH"
   },
   {
     "asset": "TRX",
     "currency": "ZEUR",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "TRX/EUR"
   },
   {
     "asset": "TRX",
     "currency": "ZUSD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "TRX/USD"
   },
   {
     "asset": "TRX",
     "currency": "XXBT",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "TRX/XBT"
   },
   {
     "asset": "UNI",
     "currency": "XETH",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "UNI/ETH"
   },
   {
     "asset": "UNI",
     "currency": "ZEUR",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "UNI/EUR"
   },
   {
     "asset": "UNI",
     "currency": "ZUSD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "UNI/USD"
   },
   {
     "asset": "UNI",
     "currency": "XXBT",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "UNI/XBT"
   },
   {
     "asset": "USDC",
     "currency": "ZAUD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "USDC/AUD"
   },
   {
     "asset": "USDC",
     "currency": "ZEUR",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "USDC/EUR"
   },
   {
     "asset": "USDC",
     "currency": "ZGBP",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "USDC/GBP"
   },
   {
     "asset": "ZUSD",
     "currency": "CHF",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "USD/CHF"
   },
   {
     "asset": "USDC",
     "currency": "ZUSD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "USDC/USD"
   },
   {
     "asset": "USDC",
     "currency": "USDT",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "USDC/USDT"
   },
   {
     "asset": "USDT",
     "currency": "ZAUD",
     "min_size": "5",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "USDT/AUD"
   },
   {
     "asset": "USDT",
     "currency": "ZCAD",
     "min_size": "5",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "USDT/CAD"
   },
   {
     "asset": "USDT",
     "currency": "CHF",
     "min_size": "5",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "USDT/CHF"
   },
   {
     "asset": "USDT",
     "currency": "ZEUR",
     "min_size": "5",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "USDT/EUR"
   },
   {
     "asset": "USDT",
     "currency": "ZGBP",
     "min_size": "5",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "USDT/GBP"
   },
   {
     "asset": "USDT",
     "currency": "ZJPY",
     "min_size": "5",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "USDT/JPY"
   },
   {
     "asset": "USDT",
     "currency": "ZUSD",
     "min_size": "5",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "USDT/USD"
   },
   {
     "asset": "WAVES",
     "currency": "XETH",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "WAVES/ETH"
   },
   {
     "asset": "WAVES",
     "currency": "ZEUR",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "WAVES/EUR"
   },
   {
     "asset": "WAVES",
     "currency": "ZUSD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "WAVES/USD"
   },
   {
     "asset": "WAVES",
     "currency": "XXBT",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "WAVES/XBT"
   },
   {
     "asset": "XXBT",
     "currency": "ZAUD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "XBT/AUD"
   },
   {
     "asset": "XXBT",
     "currency": "CHF",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "XBT/CHF"
   },
   {
     "asset": "XXBT",
     "currency": "DAI",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "XBT/DAI"
   },
   {
     "asset": "XXBT",
     "currency": "USDC",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "XBT/USDC"
   },
   {
     "asset": "XXBT",
     "currency": "USDT",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "XBT/USDT"
   },
   {
     "asset": "XXDG",
     "currency": "ZEUR",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "XDG/EUR"
   },
   {
     "asset": "XXDG",
     "currency": "ZUSD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "XDG/USD"
   },
   {
     "asset": "XETC",
     "currency": "XETH",
     "min_size": "0.3",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ETC/ETH"
   },
   {
     "asset": "XETC",
     "currency": "XXBT",
     "min_size": "0.3",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ETC/XBT"
   },
   {
     "asset": "XETC",
     "currency": "ZEUR",
     "min_size": "0.3",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ETC/EUR"
   },
   {
     "asset": "XETC",
     "currency": "ZUSD",
     "min_size": "0.3",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ETC/USD"
   },
   {
     "asset": "XETH",
     "currency": "XXBT",
     "min_size": "0.02",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ETH/XBT"
   },
   {
     "asset": "XETH",
     "currency": "ZCAD",
     "min_size": "0.02",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ETH/CAD"
   },
   {
     "asset": "XETH",
     "currency": "ZEUR",
     "min_size": "0.02",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ETH/EUR"
   },
   {
     "asset": "XETH",
     "currency": "ZGBP",
     "min_size": "0.02",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ETH/GBP"
   },
   {
     "asset": "XETH",
     "currency": "ZJPY",
     "min_size": "0.02",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ETH/JPY"
   },
   {
     "asset": "XETH",
     "currency": "ZUSD",
     "min_size": "0.02",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ETH/USD"
   },
   {
     "asset": "XLTC",
     "currency": "XXBT",
     "min_size": "0.1",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "LTC/XBT"
   },
   {
     "asset": "XLTC",
     "currency": "ZEUR",
     "min_size": "0.1",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "LTC/EUR"
   },
   {
     "asset": "XLTC",
     "currency": "ZJPY",
     "min_size": "0.1",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "LTC/JPY"
   },
   {
     "asset": "XLTC",
     "currency": "ZUSD",
     "min_size": "0.1",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "LTC/USD"
   },
   {
     "asset": "XMLN",
     "currency": "XETH",
     "min_size": "0.1",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "MLN/ETH"
   },
   {
     "asset": "XMLN",
     "currency": "XXBT",
     "min_size": "0.1",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "MLN/XBT"
   },
   {
     "asset": "XMLN",
     "currency": "ZEUR",
     "min_size": "0.1",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "MLN/EUR"
   },
   {
     "asset": "XMLN",
     "currency": "ZUSD",
     "min_size": "0.1",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "MLN/USD"
   },
   {
     "asset": "XREP",
     "currency": "XETH",
     "min_size": "0.3",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "REP/ETH"
   },
   {
     "asset": "XREP",
     "currency": "XXBT",
     "min_size": "0.3",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "REP/XBT"
   },
   {
     "asset": "XREP",
     "currency": "ZEUR",
     "min_size": "0.3",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "REP/EUR"
   },
   {
     "asset": "XREP",
     "currency": "ZUSD",
     "min_size": "0.3",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "REP/USD"
   },
   {
     "asset": "XXRP",
     "currency": "ZAUD",
     "min_size": "30",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "XRP/AUD"
   },
   {
     "asset": "XXRP",
     "currency": "XETH",
     "min_size": "30",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "XRP/ETH"
   },
   {
     "asset": "XXRP",
     "currency": "ZGBP",
     "min_size": "30",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "XRP/GBP"
   },
   {
     "asset": "XXRP",
     "currency": "USDT",
     "min_size": "30",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "XRP/USDT"
   },
   {
     "asset": "XTZ",
     "currency": "ZAUD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "XTZ/AUD"
   },
   {
     "asset": "XTZ",
     "currency": "XETH",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "XTZ/ETH"
   },
   {
     "asset": "XTZ",
     "currency": "ZEUR",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "XTZ/EUR"
   },
   {
     "asset": "XTZ",
     "currency": "ZGBP",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "XTZ/GBP"
   },
   {
     "asset": "XTZ",
     "currency": "ZUSD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "XTZ/USD"
   },
   {
     "asset": "XTZ",
     "currency": "XXBT",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "XTZ/XBT"
   },
   {
     "asset": "XXBT",
     "currency": "ZCAD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "XBT/CAD"
   },
   {
     "asset": "XXBT",
     "currency": "ZEUR",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "XBT/EUR"
   },
   {
     "asset": "XXBT",
     "currency": "ZGBP",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "XBT/GBP"
   },
   {
     "asset": "XXBT",
     "currency": "ZJPY",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "XBT/JPY"
   },
   {
     "asset": "XXBT",
     "currency": "ZUSD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "XBT/USD"
   },
   {
     "asset": "XXDG",
     "currency": "XXBT",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "XDG/XBT"
   },
   {
     "asset": "XXLM",
     "currency": "XXBT",
     "min_size": "300",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "XLM/XBT"
   },
   {
     "asset": "XXLM",
     "currency": "ZAUD",
     "min_size": "300",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "XLM/AUD"
   },
   {
     "asset": "XXLM",
     "currency": "ZEUR",
     "min_size": "300",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "XLM/EUR"
   },
   {
     "asset": "XXLM",
     "currency": "ZGBP",
     "min_size": "300",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "XLM/GBP"
   },
   {
     "asset": "XXLM",
     "currency": "ZUSD",
     "min_size": "300",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "XLM/USD"
   },
   {
     "asset": "XXMR",
     "currency": "XXBT",
     "min_size": "0.1",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "XMR/XBT"
   },
   {
     "asset": "XXMR",
     "currency": "ZEUR",
     "min_size": "0.1",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "XMR/EUR"
   },
   {
     "asset": "XXMR",
     "currency": "ZUSD",
     "min_size": "0.1",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "XMR/USD"
   },
   {
     "asset": "XXRP",
     "currency": "XXBT",
     "min_size": "30",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "XRP/XBT"
   },
   {
     "asset": "XXRP",
     "currency": "ZCAD",
     "min_size": "30",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "XRP/CAD"
   },
   {
     "asset": "XXRP",
     "currency": "ZEUR",
     "min_size": "30",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "XRP/EUR"
   },
   {
     "asset": "XXRP",
     "currency": "ZJPY",
     "min_size": "30",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "XRP/JPY"
   },
   {
     "asset": "XXRP",
     "currency": "ZUSD",
     "min_size": "30",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "XRP/USD"
   },
   {
     "asset": "XZEC",
     "currency": "XXBT",
     "min_size": "0.03",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ZEC/XBT"
   },
   {
     "asset": "XZEC",
     "currency": "ZEUR",
     "min_size": "0.03",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ZEC/EUR"
   },
   {
     "asset": "XZEC",
     "currency": "ZUSD",
     "min_size": "0.03",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "ZEC/USD"
   },
   {
     "asset": "YFI",
     "currency": "ZAUD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "YFI/AUD"
   },
   {
     "asset": "YFI",
     "currency": "XETH",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "YFI/ETH"
   },
   {
     "asset": "YFI",
     "currency": "ZEUR",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "YFI/EUR"
   },
   {
     "asset": "YFI",
     "currency": "ZGBP",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "YFI/GBP"
   },
   {
     "asset": "YFI",
     "currency": "ZUSD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "YFI/USD"
   },
   {
     "asset": "YFI",
     "currency": "XXBT",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "YFI/XBT"
   },
   {
     "asset": "ZEUR",
     "currency": "ZUSD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "EUR/USD"
   },
   {
     "asset": "ZGBP",
     "currency": "ZUSD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "GBP/USD"
   },
   {
     "asset": "ZUSD",
     "currency": "ZCAD",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "USD/CAD"
   },
   {
     "asset": "ZUSD",
     "currency": "ZJPY",
     "min_size": "0.01",
-    "increment": "0.01",
+    "increment": "0.00010000",
     "label": "USD/JPY"
   }
 ]

--- a/extensions/exchanges/kraken/update-products.sh
+++ b/extensions/exchanges/kraken/update-products.sh
@@ -67,7 +67,7 @@ function addProduct(base, quote, altname) {
     asset: base,
     currency: quote,
     min_size: min_size,
-    increment: '0.01',
+    increment: '0.00100000',
     label: getPair(base) + '/' + getPair(quote)
   })
 }

--- a/extensions/exchanges/kraken/update-products.sh
+++ b/extensions/exchanges/kraken/update-products.sh
@@ -6,68 +6,12 @@ var kraken = new KrakenClient()
 var mapping
 var products = []
 
-function addProduct(base, quote, altname) {
-  var min_size = '0.01'
-  switch (base) {
-  case 'XREP':
-    min_size = '0.3'
-    break;
-  case 'XBT':
-    min_size = '0.002'
-    break;
-  case 'BCH':
-    min_size = '0.002'
-    break;
-  case 'DASH':
-    min_size = '0.03'
-    break;
-  case 'EOS':
-    min_size = '3.0'
-    break;
-  case 'XETH':
-    min_size = '0.02'
-    break;
-  case 'XETC':
-    min_size = '0.3'
-    break;
-  case 'GNO':
-    min_size = '0.03'
-    break;
-  case 'XICN':
-    min_size = '2.0'
-    break;
-  case 'XLTC':
-    min_size = '0.1'
-    break;
-  case 'XMLN':
-    min_size = '0.1'
-    break;
-  case 'XLTC':
-    min_size = '0.1'
-    break;
-  case 'XXMR':
-    min_size = '0.1'
-    break;
-  case 'XXRP':
-    min_size = '30'
-    break;
-  case 'XXLM':
-    min_size = '300'
-    break;
-  case 'XZEC':
-    min_size = '0.03'
-    break;
-  case 'USDT':
-    min_size = '5'
-    break;
-  default:
-    break;
-  }
+function addProduct(base, quote, altname, min_size, increment) {
   products.push({
     asset: base,
     currency: quote,
-    min_size: min_size,
-    increment: '0.00100000',
+    min_size: parseFloat(min_size).toFixed(10),
+    increment: (10 ** (-1 * increment)).toFixed(10),
     label: getPair(base) + '/' + getPair(quote)
   })
 }
@@ -91,7 +35,8 @@ kraken.api('Assets', null, function(error, data) {
       } else {
         Object.keys(data.result).forEach(function(result) {
           if (!result.match('\.d')) {
-            addProduct(data.result[result].base, data.result[result].quote, data.result[result].altname)
+            addProduct(data.result[result].base, data.result[result].quote, data.result[result].altname,
+                       data.result[result].ordermin, data.result[result].pair_decimals)
           }
         })
         var target = require('path').resolve(__dirname, 'products.json')

--- a/extensions/exchanges/sim/exchange.js
+++ b/extensions/exchanges/sim/exchange.js
@@ -15,7 +15,6 @@ module.exports = function sim (conf, s) {
   var last_order_id = 1001
   var orders = {}
   var openOrders = {}
-  let debug = false // debug output specific to the sim exchange
 
   // When orders change in any way, it's likely our "_hold" values have changed. Recalculate them
   function recalcHold() {
@@ -88,9 +87,9 @@ module.exports = function sim (conf, s) {
 
     buy: function (opts, cb) {
       setTimeout(function() {
-        if (debug) console.log(`buying ${opts.size * opts.price} vs on hold: ${balance.currency} - ${balance.currency_hold} = ${balance.currency - balance.currency_hold}`)
+        if (so.debug) console.log(`buying ${opts.size * opts.price} vs on hold: ${balance.currency} - ${balance.currency_hold} = ${balance.currency - balance.currency_hold}`)
         if (opts.size * opts.price > (balance.currency - balance.currency_hold)) {
-          if (debug) console.log('nope')
+          if (so.debug) console.log('nope')
           return cb(null, { status: 'rejected', reject_reason: 'balance'})
         }
 
@@ -123,9 +122,9 @@ module.exports = function sim (conf, s) {
 
     sell: function (opts, cb) {
       setTimeout(function() {
-        if (debug) console.log(`selling ${opts.size} vs on hold: ${balance.asset} - ${balance.asset_hold} = ${balance.asset - balance.asset_hold}`)
+        if (so.debug) console.log(`selling ${opts.size} vs on hold: ${balance.asset} - ${balance.asset_hold} = ${balance.asset - balance.asset_hold}`)
         if (opts.size > (balance.asset - balance.asset_hold)) {
-          if (debug) console.log('nope')
+          if (so.debug) console.log('nope')
           return cb(null, { status: 'rejected', reject_reason: 'balance'})
         }
 
@@ -228,13 +227,13 @@ module.exports = function sim (conf, s) {
     order.remaining_size = order.size - order.filled_size
 
     if (order.remaining_size <= 0) {
-      if (debug) console.log('full fill bought')
+      if (so.debug) console.log('full fill bought')
       order.status = 'done'
       order.done_at = trade.time
       delete openOrders['~' + order.id]
     }
     else {
-      if (debug) console.log('partial fill buy')
+      if (so.debug) console.log('partial fill buy')
     }
   }
 
@@ -268,13 +267,13 @@ module.exports = function sim (conf, s) {
     order.remaining_size = order.size - order.filled_size
 
     if (order.remaining_size <= 0) {
-      if (debug) console.log('full fill sold')
+      if (so.debug) console.log('full fill sold')
       order.status = 'done'
       order.done_at = trade.time
       delete openOrders['~' + order.id]
     }
     else {
-      if (debug) console.log('partial fill sell')
+      if (so.debug) console.log('partial fill sell')
     }
   }
 


### PR DESCRIPTION
This pull request accomplishes the following:

* Simulation is currently broken for kraken, orders do not complete because the increment is not in sync with Kraken. The update-products script was modified to get the increment and min_size from the AssetPairs endopoint (fixes #1454, fixes #514).
* The function joinProductFormatted was updated for current 'X' and 'Z' formatted pairs (fixes #2615).

There is still a bug with the simulation, as its not lowwing correctly the numbers of wins. I'll be doing a separate PR for that.