### PR TITLE
Revert "Update docker-compose.yml"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: deviavir/zenbot:unstable
+    image: fculpo/zenbot:latest
     volumes:
       - ./simulations/:/app/simulations/
       - ./conf.js:/app/conf.js:ro


### PR DESCRIPTION
Reverts DeviaVir/zenbot#2642

The latest deviavir dockerfile image is outdated by 3 months. The last posted fculpo image (via the website) is 8 months but after inspecting it was updated 4 days ago. The dockerfile website is not maintaining the latest version. Recommend rolling back the changes and update the doc to read - "docker pull fculpo/zenbot:latest"